### PR TITLE
페이지 UI: 프로필 설정

### DIFF
--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,42 +1,7 @@
-'use client';
-
-import { usePathname } from 'next/navigation';
-import Title from '@/components/common/title/Title';
-
-const titleData: Record<string, { title: string; description: string }> = {
-  '/signup': {
-    title: '이메일로 회원가입',
-    description: '',
-  },
-  'set-profile': {
-    title: '프로필 설정',
-    description: '나중에 언제든지 변경할 수 있습니다.',
-  },
-  '/login': {
-    title: '로그인',
-    description: '',
-  },
-};
-
 export default function AuthLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  const pathname = usePathname();
-  const currentTitle = titleData[pathname] || {
-    title: '',
-    description: '',
-  };
-
-  return (
-    <div className="w-full px-34px">
-      <Title
-        padding="pt-30px pb-10"
-        title={currentTitle.title}
-        description={currentTitle.description}
-      />
-      <main>{children}</main>
-    </div>
-  );
+  return <div className="w-full px-34px">{children}</div>;
 }

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import Title from '@/components/common/title/Title';
+
+const titleData: Record<string, { title: string; description: string }> = {
+  '/signup': {
+    title: '이메일로 회원가입',
+    description: '',
+  },
+  'set-profile': {
+    title: '프로필 설정',
+    description: '나중에 언제든지 변경할 수 있습니다.',
+  },
+  '/login': {
+    title: '로그인',
+    description: '',
+  },
+};
+
+export default function AuthLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const pathname = usePathname();
+  const currentTitle = titleData[pathname] || {
+    title: '',
+    description: '',
+  };
+
+  return (
+    <div className="w-full px-34px">
+      <Title
+        padding="pt-30px pb-10"
+        title={currentTitle.title}
+        description={currentTitle.description}
+      />
+      <main>{children}</main>
+    </div>
+  );
+}

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,11 +1,15 @@
+import Link from 'next/link';
 import AuthForm from '@/components/common/form/auth-form/AuthForm';
-import Title from '@/components/common/title/Title';
 
 export default function page() {
   return (
-    <div className="w-full px-34px">
-      <Title padding="pt-30px pb-10" title="로그인" />
+    <>
       <AuthForm type="login" />
-    </div>
+      <Link href="/signup">
+        <button className="mx-auto mt-4 block p-1 text-12px font-normal text-gray-300">
+          이메일로 회원가입
+        </button>
+      </Link>
+    </>
   );
 }

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,15 +1,15 @@
 import Link from 'next/link';
 import AuthForm from '@/components/common/form/auth-form/AuthForm';
 import Title from '@/components/common/title/Title';
-import { titleText } from '@/constants/titleText';
+import { TITLE_TEXT } from '@/constants/titleText';
 
 export default function page() {
   return (
     <>
       <Title
         padding="pt-30px pb-10"
-        title={titleText.login.title}
-        description={titleText.login.description}
+        title={TITLE_TEXT.login.title}
+        description={TITLE_TEXT.login.description}
       />
       <AuthForm type="login" />
       <Link href="/signup">

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,9 +1,16 @@
 import Link from 'next/link';
 import AuthForm from '@/components/common/form/auth-form/AuthForm';
+import Title from '@/components/common/title/Title';
+import { titleText } from '@/constants/titleText';
 
 export default function page() {
   return (
     <>
+      <Title
+        padding="pt-30px pb-10"
+        title={titleText.login.title}
+        description={titleText.login.description}
+      />
       <AuthForm type="login" />
       <Link href="/signup">
         <button className="mx-auto mt-4 block p-1 text-12px font-normal text-gray-300">

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -4,7 +4,7 @@ import AuthForm from '@/components/common/form/auth-form/AuthForm';
 import ProfileForm from '@/components/common/form/auth-form/ProfileForm';
 import Title from '@/components/common/title/Title';
 import { titleText } from '@/constants/titleText';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 export default function page() {
   const [step, setStep] = useState(1);
@@ -12,7 +12,28 @@ export default function page() {
   // 다음 버튼을 눌렀을 때 next step으로 이동 (프로필 설정 페이지)
   const handleNext = () => {
     setStep((currentStep) => currentStep + 1);
+    window.history.pushState(null, ''); // 히스토리 스택에 새로운 상태 추가
   };
+
+  // 뒤로 가기 시 이전 step으로 이동 (회원가입 페이지)
+  const handleBack = () => {
+    if (step > 1) {
+      setStep((currentStep) => currentStep - 1);
+    }
+  };
+
+  useEffect(() => {
+    const handlePopState = () => {
+      handleBack();
+    };
+
+    // popstate 이벤트 감지 (브라우저 뒤로 가기 버튼 감지)
+    window.addEventListener('popstate', handlePopState);
+
+    return () => {
+      window.removeEventListener('popstate', handlePopState);
+    };
+  }, [step]);
 
   const titleInfo = titleText[step === 1 ? 'signup' : 'set-profile'];
   const padding = step === 1 ? 'pt-30px pb-10' : 'py-30px';

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -1,11 +1,31 @@
+'use client';
+
 import AuthForm from '@/components/common/form/auth-form/AuthForm';
+import ProfileForm from '@/components/common/form/auth-form/ProfileForm';
 import Title from '@/components/common/title/Title';
+import { titleText } from '@/constants/titleText';
+import { useState } from 'react';
 
 export default function page() {
+  const [step, setStep] = useState(1);
+
+  // 다음 버튼을 눌렀을 때 next step으로 이동 (프로필 설정 페이지)
+  const handleNext = () => {
+    setStep((currentStep) => currentStep + 1);
+  };
+
+  const titleInfo = titleText[step === 1 ? 'signup' : 'set-profile'];
+  const padding = step === 1 ? 'pt-30px pb-10' : 'py-30px';
+
   return (
-    <div className="w-full px-34px">
-      <Title padding="pt-30px pb-10" title="이메일로 회원가입" />
-      <AuthForm />
-    </div>
+    <>
+      <Title
+        padding={padding}
+        title={titleInfo.title}
+        description={titleInfo.description}
+      />
+      {step === 1 && <AuthForm type="signup" onNext={handleNext} />}
+      {step === 2 && <ProfileForm />}
+    </>
   );
 }

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -3,24 +3,24 @@
 import AuthForm from '@/components/common/form/auth-form/AuthForm';
 import ProfileForm from '@/components/common/form/auth-form/ProfileForm';
 import Title from '@/components/common/title/Title';
-import { titleText } from '@/constants/titleText';
-import { useEffect, useState } from 'react';
+import { TITLE_TEXT } from '@/constants/titleText';
+import { useCallback, useEffect, useState } from 'react';
 
 export default function page() {
   const [step, setStep] = useState(1);
 
   // 다음 버튼을 눌렀을 때 next step으로 이동 (프로필 설정 페이지)
-  const handleNext = () => {
+  const handleNext = useCallback(() => {
     setStep((currentStep) => currentStep + 1);
     window.history.pushState(null, ''); // 히스토리 스택에 새로운 상태 추가
-  };
+  }, []);
 
   // 뒤로 가기 시 이전 step으로 이동 (회원가입 페이지)
-  const handleBack = () => {
+  const handleBack = useCallback(() => {
     if (step > 1) {
       setStep((currentStep) => currentStep - 1);
     }
-  };
+  }, [step]);
 
   useEffect(() => {
     const handlePopState = () => {
@@ -33,9 +33,9 @@ export default function page() {
     return () => {
       window.removeEventListener('popstate', handlePopState);
     };
-  }, [step]);
+  }, [handleBack]);
 
-  const titleInfo = titleText[step === 1 ? 'signup' : 'set-profile'];
+  const titleInfo = TITLE_TEXT[step === 1 ? 'signup' : 'set-profile'];
   const padding = step === 1 ? 'pt-30px pb-10' : 'py-30px';
 
   return (

--- a/src/components/common/form/auth-form/AuthForm.tsx
+++ b/src/components/common/form/auth-form/AuthForm.tsx
@@ -3,6 +3,7 @@ import { UnderlineInput } from '@/components/common/input/UnderlineInput';
 
 interface AuthFormProps {
   type: 'login' | 'signup';
+  onNext?: () => void; // 버튼 클릭 시 호출할 함수
 }
 
 const authFields = [
@@ -14,7 +15,7 @@ const authFields = [
   },
 ];
 
-export default function AuthForm({ type = 'signup' }: AuthFormProps) {
+export default function AuthForm({ type, onNext }: AuthFormProps) {
   return (
     <form className="flex-center gap-30px">
       <div className="flex-center gap-4">
@@ -30,7 +31,7 @@ export default function AuthForm({ type = 'signup' }: AuthFormProps) {
           />
         ))}
       </div>
-      <CustomButton color="primary" size="l" radius="full">
+      <CustomButton onClick={onNext} color="primary" size="l" radius="full">
         {type === 'signup' ? '다음' : '로그인'}
       </CustomButton>
     </form>

--- a/src/components/common/form/auth-form/ProfileForm.tsx
+++ b/src/components/common/form/auth-form/ProfileForm.tsx
@@ -1,0 +1,59 @@
+import { CustomButton } from '@/components/common/button/Button';
+import { UnderlineInput } from '@/components/common/input/UnderlineInput';
+
+const profileFields = [
+  {
+    type: 'text',
+    label: '사용자 이름',
+    placeholder: '2~10자 이내여야 합니다.',
+  },
+  {
+    type: 'email',
+    label: '계정 ID',
+    placeholder: '영문, 숫자, 특수문자(.), (_)만 사용 가능합니다..',
+  },
+  {
+    type: 'text',
+    label: '소개',
+    placeholder: '자신과 판매할 상품에 대해 소개해 주세요!.',
+  },
+];
+
+export default function ProfileForm() {
+  return (
+    <form className="flex-center gap-30px" onSubmit={() => '가입완!'}>
+      <div>
+        <label htmlFor="profile-upload" className="relative">
+          <img src="/assets/icons/basic-profile-img-.svg" alt="프로필 이미지" />
+          <img
+            src="/assets/icons/upload-file.svg"
+            alt="프로필 이미지"
+            className="absolute bottom-0 right-0 w-9"
+          />
+        </label>
+        <input
+          type="file"
+          accept="image/*"
+          className="hidden"
+          id="profile-upload"
+        />
+      </div>
+      <div className="flex-center gap-4">
+        {/* 에러 시 isInvalid  ture */}
+        {profileFields.map((field) => (
+          <UnderlineInput
+            key={field.type}
+            isClearable
+            variant="underlined"
+            type={field.type}
+            label={field.label}
+            placeholder={field.placeholder}
+          />
+        ))}
+      </div>
+      <CustomButton color="primary" size="l" radius="full">
+        감귤마켓 시작하기
+      </CustomButton>
+    </form>
+  );
+}

--- a/src/components/common/title/Title.tsx
+++ b/src/components/common/title/Title.tsx
@@ -9,7 +9,9 @@ export default function Title({ title, description, padding }: TitleProps) {
     <header className={`flex-center ${padding} ${description ? 'gap-3' : ''}`}>
       <h1 className="font-medium">{title}</h1>
       {description && (
-        <p className="text-14px font-normal text-gray-300">{description}</p>
+        <p className="leading-14px text-14px font-normal text-gray-300">
+          {description}
+        </p>
       )}
     </header>
   );

--- a/src/constants/titleText.ts
+++ b/src/constants/titleText.ts
@@ -1,0 +1,15 @@
+export const titleText: Record<string, { title: string; description: string }> =
+  {
+    signup: {
+      title: '이메일로 회원가입',
+      description: '',
+    },
+    'set-profile': {
+      title: '프로필 설정',
+      description: '나중에 언제든지 변경할 수 있습니다.',
+    },
+    login: {
+      title: '로그인',
+      description: '',
+    },
+  };

--- a/src/constants/titleText.ts
+++ b/src/constants/titleText.ts
@@ -1,15 +1,17 @@
-export const titleText: Record<string, { title: string; description: string }> =
-  {
-    signup: {
-      title: '이메일로 회원가입',
-      description: '',
-    },
-    'set-profile': {
-      title: '프로필 설정',
-      description: '나중에 언제든지 변경할 수 있습니다.',
-    },
-    login: {
-      title: '로그인',
-      description: '',
-    },
-  };
+export const TITLE_TEXT: Record<
+  string,
+  { title: string; description: string }
+> = {
+  signup: {
+    title: '이메일로 회원가입',
+    description: '',
+  },
+  'set-profile': {
+    title: '프로필 설정',
+    description: '나중에 언제든지 변경할 수 있습니다.',
+  },
+  login: {
+    title: '로그인',
+    description: '',
+  },
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -23,6 +23,7 @@ const config: Config = {
       },
       backgroundImage: {},
       colors: tokens.colors,
+      lineHeight: tokens.fontSize,
       fontSize: tokens.fontSize,
       zIndex: tokens.zIndex,
       spacing: tokens.spacing,


### PR DESCRIPTION
## 📍 PR 타입

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제한 경우
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

</br>

## 🖇️ 반영 브랜치

<!-- ex) feat/login -> dev -->
page/ui/set/profile

</br>

## 🛠️ 작업 내용

<!-- 어떤 작업을 했는지 -->
- (auth) 폴더 공통 layout.tsx 구성
- ProfileForm 컴포넌트 UI 구현
- 회원가입 시 step에 따라 각 단계에 맞는 컴포넌트가 렌더링되도록 구현(step1 -> 이메일, 비밀번호 설정 / step2 -> 프로필 설정)
- 뒤로가기 시 이전 step으로 되돌아가도록 구현(따로 뒤로가기 버튼이 없어 브라우저의 뒤로가기 버튼을 눌렀을 시 이전의 단걔로 돌아가도록 구현)
- useCallback을 사용해 함수가 불필요하게 재생성되지 않도록 구현

</br>

## 💣 이슈
<!-- 작업 시 이슈 -->

1. Title컴포넌트를 auth layout에 구성하고 싶었으나 프로필 설정의 url을 따로 만들지 않아 건드릴수록 복잡해져서 결국 하위 페이지로 이동..
2. 프로필 설정에서 뒤로가기 후 다시 앞으로 가기 했을때 빈 페이지만 나오는데 이 부분 어떤식으로 처리할지 생각하기
