### PR TITLE
페이지 기능: 로그인

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "string-width": "^7.2.0"
   },
   "devDependencies": {
-    "@testing-library/jest-dom": "^6.6.1",
+    "@testing-library/dom": "^10.4.0",
+    "@testing-library/jest-dom": "^6.6.2",
     "@testing-library/react": "^16.0.1",
     "@types/jest": "^29.5.13",
     "@types/node": "^20",

--- a/src/api/apiRequests/auth.ts
+++ b/src/api/apiRequests/auth.ts
@@ -1,9 +1,23 @@
 import { postRequest } from '@/api/requests';
-import { ISignUpRequest, ISignupResponse } from '@/api/types/auth';
+import {
+  ILoginRequest,
+  ILoginResponse,
+  ISignUpRequest,
+  ISignupResponse,
+} from '@/api/types/auth';
 
 export const signup = async (data: ISignUpRequest) => {
   const response = await postRequest<ISignupResponse, ISignUpRequest>(
     '/user',
+    data,
+  );
+
+  return response;
+};
+
+export const login = async (data: ILoginRequest) => {
+  const response = await postRequest<ILoginResponse, ILoginRequest>(
+    '/user/login',
     data,
   );
 

--- a/src/api/types/auth.ts
+++ b/src/api/types/auth.ts
@@ -6,16 +6,13 @@ export interface IUser {
   image: string;
 }
 
-// 공통된 응답 구조 인터페이스
+/* -- 공통 응답 구조 인터페이스 -- */
 export interface IBaseResponse<T> {
   message: string;
   user: IUser & T;
 }
 
-// 회원가입 성공시 응답
-export type ISignupResponse = IBaseResponse<{ intro: string }>;
-
-// 회원가입 요청
+/* -- 회원가입 요청, 응답 -- */
 export interface ISignUpRequest {
   username: string;
   email: string;
@@ -24,3 +21,13 @@ export interface ISignUpRequest {
   intro: string;
   image: string;
 }
+
+export type ISignupResponse = IBaseResponse<{ intro: string }>;
+
+/* -- 로그인 요청, 응답 -- */
+export interface ILoginRequest {
+  email: string;
+  password: string;
+}
+
+export type ILoginResponse = IBaseResponse<{ token: string }>;

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -3,25 +3,29 @@
 import Link from 'next/link';
 import { FormProvider, useForm } from 'react-hook-form';
 
+import { ILoginRequest } from '@/api/types/auth';
 import CustomButton from '@/components/common/button/Button';
 import FormTemplate from '@/components/common/form/auth-form/FormTemplate';
 import Title from '@/components/common/title/Title';
 import { loginFields } from '@/config/authFieldConfig';
 import { TITLE_TEXT } from '@/constants/titleText';
+import useLogin from '@/hooks/queries/auth/useLogin';
 
 export default function Login() {
   const methods = useForm({
     mode: 'onBlur',
     defaultValues: { email: '', password: '' },
   });
+  const { mutate } = useLogin();
 
   const {
     handleSubmit,
     formState: { isValid },
   } = methods;
 
-  const onSubmit = () => {
+  const onSubmit = (data: ILoginRequest) => {
     console.log('성공');
+    mutate(data);
   };
 
   return (

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,9 +1,29 @@
+'use client';
+
 import Link from 'next/link';
-import AuthForm from '@/components/common/form/auth-form/AuthForm';
+import { FormProvider, useForm } from 'react-hook-form';
+
+import CustomButton from '@/components/common/button/Button';
+import FormTemplate from '@/components/common/form/auth-form/FormTemplate';
 import Title from '@/components/common/title/Title';
+import { loginFields } from '@/config/authFieldConfig';
 import { TITLE_TEXT } from '@/constants/titleText';
 
-export default function page() {
+export default function Login() {
+  const methods = useForm({
+    mode: 'onBlur',
+    defaultValues: { email: '', password: '' },
+  });
+
+  const {
+    handleSubmit,
+    formState: { isValid },
+  } = methods;
+
+  const onSubmit = () => {
+    console.log('성공');
+  };
+
   return (
     <>
       <Title
@@ -11,9 +31,26 @@ export default function page() {
         title={TITLE_TEXT.login.title}
         description={TITLE_TEXT.login.description}
       />
-      <AuthForm type="login" />
+      <FormProvider {...methods}>
+        <form onSubmit={handleSubmit(onSubmit)}>
+          <FormTemplate fields={loginFields} />
+          <CustomButton
+            type="submit"
+            color="primary"
+            size="l"
+            radius="full"
+            className="mt-30px"
+            isDisabled={!isValid}
+          >
+            로그인
+          </CustomButton>
+        </form>
+      </FormProvider>
       <Link href="/signup">
-        <button className="mx-auto mt-4 block p-1 text-12px font-normal text-gray-300">
+        <button
+          type="button"
+          className="mx-auto mt-4 block p-1 text-12px font-normal text-gray-300"
+        >
           이메일로 회원가입
         </button>
       </Link>

--- a/src/components/common/form/auth-form/FormTemplate.tsx
+++ b/src/components/common/form/auth-form/FormTemplate.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-nested-ternary */
-
 'use client';
 
 import { useFormContext } from 'react-hook-form';
@@ -22,19 +20,19 @@ export default function FormTemplate({ fields, children }: FormTemplateProps) {
     <fieldset className="flex-center gap-4">
       {children}
       {Object.entries(fields).map(([name, field]) => {
+        const inputType =
+          {
+            email: 'email',
+            password: 'password',
+          }[name] || 'text';
+
         return (
           <UnderlineInput
             key={name}
             {...register(name, field.validation)}
             isClearable
             variant="underlined"
-            type={
-              name === 'email'
-                ? 'email'
-                : name === 'password'
-                  ? 'password'
-                  : 'text'
-            }
+            type={inputType}
             label={field.label}
             placeholder={field.placeholder}
             isInvalid={!!errors[name]}

--- a/src/components/common/form/auth-form/FormTemplate.tsx
+++ b/src/components/common/form/auth-form/FormTemplate.tsx
@@ -15,16 +15,13 @@ interface FormTemplateProps {
 export default function FormTemplate({ fields, children }: FormTemplateProps) {
   const {
     register,
-    formState: { errors, touchedFields },
+    formState: { errors },
   } = useFormContext();
 
   return (
     <fieldset className="flex-center gap-4">
       {children}
       {Object.entries(fields).map(([name, field]) => {
-        // 필드가 터치되었을 때만 에러 표시
-        const hasError = touchedFields[name] && errors[name];
-
         return (
           <UnderlineInput
             key={name}
@@ -40,7 +37,7 @@ export default function FormTemplate({ fields, children }: FormTemplateProps) {
             }
             label={field.label}
             placeholder={field.placeholder}
-            isInvalid={!!hasError}
+            isInvalid={!!errors[name]}
             errorMessage={errors[name]?.message?.toString()}
           />
         );

--- a/src/config/authFieldConfig.ts
+++ b/src/config/authFieldConfig.ts
@@ -48,9 +48,11 @@ export const loginFields: IFields = {
   email: {
     label: '이메일',
     placeholder: '이메일을 입력하세요.',
+    validation: emailValidation,
   },
   password: {
     label: '비밀번호',
     placeholder: '비밀번호를 입력하세요.',
+    validation: passwordValidation,
   },
 };

--- a/src/hooks/queries/auth/useLogin.ts
+++ b/src/hooks/queries/auth/useLogin.ts
@@ -1,0 +1,26 @@
+import { useMutation } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+import { useRouter } from 'next/navigation';
+
+import { login } from '@/api/apiRequests/auth';
+import { ILoginRequest, ILoginResponse } from '@/api/types/auth';
+
+function useLogin() {
+  const router = useRouter();
+
+  const onSuccess = () => {
+    router.push('/');
+  };
+
+  const onError = (error: AxiosError) => {
+    console.error(error);
+  };
+
+  return useMutation<ILoginResponse, AxiosError, ILoginRequest>({
+    mutationFn: login,
+    onSuccess,
+    onError,
+  });
+}
+
+export default useLogin;


### PR DESCRIPTION
## 📍 PR 타입

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제한 경우
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [x] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

</br>

## 🖇️ 반영 브랜치

<!-- ex) feat/login -> dev -->
page/feature/login

</br>

## 🛠️ 작업 내용

<!-- 어떤 작업을 했는지 -->
- 로그인 폼에 react-hook-form 적용
- 로그인 API 요청 및 응답 type 정의
- 로그인 API 요청 함수 구현
- useMutation 훅을 사용해 로그인 API 호출하는 쿼리훅 구현
- @testing-library/react 및 @testing-library/dom 재설치

</br>

## 💣 이슈

<!-- 작업 시 이슈 -->
- form Input에서 field가 터치되지 않으면 에러를 표시하지 못하는 버그 발생
        ```
const hasError = touchedFields[name] && errors[name];
        return (
          <UnderlineInput
            ...
            placeholder={field.placeholder}
            isInvalid={!!hasError}
           />
        )```
 이 코드로 인해 field가 터치 되고 valid error가 있을 때만 에어를 렌더링 해주고 있어서 아무것도 입력하지 않고 버튼을 눌렀을 때 에러상황을 렌더링해주지 못하는 이슈가 발생
-> ```isInvalid={!!errors[name]}``` 로 수정하여 아무것도 입력하지 않았을 경우에도 에러를 나타내 주도록 구현