### PR TITLE
페이지 기능: 게시글 업로드

### DIFF
--- a/src/api/apiRequests/uploadPost.ts
+++ b/src/api/apiRequests/uploadPost.ts
@@ -1,0 +1,11 @@
+import { postRequest } from '@/api/requests';
+import { IUploadPostRequest, IPostDetail } from '@/api/types/post';
+
+export const uploadPost = async (data: IUploadPostRequest) => {
+  const response = await postRequest<IPostDetail, IUploadPostRequest>(
+    '/post',
+    data,
+  );
+
+  return response;
+};

--- a/src/api/types/post.ts
+++ b/src/api/types/post.ts
@@ -20,3 +20,7 @@ export type IPostWithoutAuthor = Omit<IPost, 'author'>;
 export interface IPostList {
   posts: IPost[];
 }
+
+export interface IUploadPostRequest {
+  post: Pick<IPost, 'image' | 'content'>;
+}

--- a/src/app/(private)/layout.tsx
+++ b/src/app/(private)/layout.tsx
@@ -1,5 +1,6 @@
 import BottomNav from '@/components/common/bottom-nav/BottomNav';
 import Header from '@/components/common/header/Header';
+import ContextProvider from '@/context/provider';
 
 export default function PrivateLayout({
   children,
@@ -7,10 +8,10 @@ export default function PrivateLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <>
+    <ContextProvider>
       <Header />
       {children}
       <BottomNav />
-    </>
+    </ContextProvider>
   );
 }

--- a/src/app/(private)/upload/page.tsx
+++ b/src/app/(private)/upload/page.tsx
@@ -1,0 +1,5 @@
+import UploadPage from '@/components/pages/UploadPage';
+
+export default function page() {
+  return <UploadPage />;
+}

--- a/src/components/common/form/upload-form/UploadForm.tsx
+++ b/src/components/common/form/upload-form/UploadForm.tsx
@@ -1,0 +1,26 @@
+import { useFormContext } from 'react-hook-form';
+
+import { IUploadPostRequest } from '@/api/types/post';
+
+interface UploadFormProps {
+  onSubmit: (data: IUploadPostRequest) => void;
+}
+
+export default function UploadForm({ onSubmit }: UploadFormProps) {
+  // useFormContext의 타입 지정
+  const { register, handleSubmit } = useFormContext<IUploadPostRequest>();
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <input
+        {...register('post.content', { required: '게시글을 입력해주세요.' })}
+        placeholder="게시글 입력하기"
+      />
+      <input
+        {...register('post.image')}
+        accept="image/jpg, image/jpeg, image/png, image/gif"
+        type="file"
+      />
+    </form>
+  );
+}

--- a/src/components/common/form/upload-form/UploadForm.tsx
+++ b/src/components/common/form/upload-form/UploadForm.tsx
@@ -2,16 +2,12 @@ import { useFormContext } from 'react-hook-form';
 
 import { IUploadPostRequest } from '@/api/types/post';
 
-interface UploadFormProps {
-  onSubmit: (data: IUploadPostRequest) => void;
-}
-
-export default function UploadForm({ onSubmit }: UploadFormProps) {
+export default function UploadForm() {
   // useFormContext의 타입 지정
-  const { register, handleSubmit } = useFormContext<IUploadPostRequest>();
+  const { register } = useFormContext<IUploadPostRequest>();
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)}>
+    <form>
       <input
         {...register('post.content', { required: '게시글을 입력해주세요.' })}
         placeholder="게시글 입력하기"

--- a/src/components/common/header/Header.tsx
+++ b/src/components/common/header/Header.tsx
@@ -3,9 +3,10 @@
 import { usePathname } from 'next/navigation';
 
 import { headerConfig, IHeaderConfig } from '@/config/headerConfig';
+import { useHeaderContext } from '@/context/provider/headerContext';
+import useNavigate from '@/hooks/useNavigate';
 
 import withHeader from './withHeader';
-import useNavigate from '@/hooks/useNavigate';
 
 const getHeaderConfig = (pathname: string): IHeaderConfig | undefined => {
   if (pathname.startsWith('/post')) return headerConfig['/post'];
@@ -14,12 +15,12 @@ const getHeaderConfig = (pathname: string): IHeaderConfig | undefined => {
 
 export default function Header() {
   const pathname = usePathname();
+  const { goBack, goTo } = useNavigate();
+  const { setIsHeaderClick } = useHeaderContext();
 
   const config = getHeaderConfig(pathname);
 
   if (!config) return null;
-
-  const { goBack, goTo } = useNavigate();
 
   const handleSearch = (searchTerm: string) => {
     console.log('ref 작동하심?', searchTerm);
@@ -36,8 +37,8 @@ export default function Header() {
         console.log('더보기 모달 open');
         break;
       case '/upload':
-        // handleUpload();
-        goTo('/');
+        setIsHeaderClick(true);
+        // console.log('upload header click');
         break;
       default:
         break;

--- a/src/components/common/header/withHeader.tsx
+++ b/src/components/common/header/withHeader.tsx
@@ -49,7 +49,10 @@ export default function withHeader(
           </button>
         )}
         {RightButton && (
-          <RightButton {...(rightButtonProps as ICustomButtonProps)} />
+          <RightButton
+            {...(rightButtonProps as ICustomButtonProps)}
+            onClick={onRightClick}
+          />
         )}
         {RightSearchForm && (
           <RightSearchForm {...(rightSearchFormProps as ISearchFormProps)} />

--- a/src/components/pages/PostDetailsPage.tsx
+++ b/src/components/pages/PostDetailsPage.tsx
@@ -7,8 +7,8 @@ import { IComment, ICommentRequest } from '@/api/types/comment';
 import CommentForm from '@/components/common/form/comment-form/CommentForm';
 import CommentCard from '@/components/common/post-item/comment-card/CommentCard';
 import PostItem from '@/components/common/post-item/PostItem';
-import useCommentList from '@/hooks/queries/post/useCommentList';
-import useCreateComment from '@/hooks/queries/post/useCreateComment';
+import useCommentList from '@/hooks/queries/comment/useCommentList';
+import useCreateComment from '@/hooks/queries/comment/useCreateComment';
 import usePostDetail from '@/hooks/queries/post/usePostDetail';
 
 interface PostDetailPageProps {

--- a/src/components/pages/UploadPage.tsx
+++ b/src/components/pages/UploadPage.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import { IUploadPostRequest } from '@/api/types/post';
@@ -20,11 +20,14 @@ export default function UploadPage() {
     },
   });
 
-  const onSubmit = (data: IUploadPostRequest) => {
-    console.log(isHeaderClick);
-    console.log(data); // 제출된 폼 데이터 출력
-    uploadPost(data);
-  };
+  const onSubmit = useCallback(
+    (data: IUploadPostRequest) => {
+      console.log('isHeaderClick:', isHeaderClick);
+      console.log('Data:', data);
+      uploadPost(data);
+    },
+    [isHeaderClick, uploadPost],
+  );
 
   useEffect(() => {
     if (isHeaderClick) {

--- a/src/components/pages/UploadPage.tsx
+++ b/src/components/pages/UploadPage.tsx
@@ -1,11 +1,14 @@
 'use client';
 
+import { useEffect } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import { IUploadPostRequest } from '@/api/types/post';
 import UploadForm from '@/components/common/form/upload-form/UploadForm';
+import { useHeaderContext } from '@/context/provider/headerContext';
 
 export default function UploadPage() {
+  const { isHeaderClick, setIsHeaderClick } = useHeaderContext();
   const methods = useForm({
     defaultValues: {
       post: {
@@ -16,12 +19,22 @@ export default function UploadPage() {
   });
 
   const onSubmit = (data: IUploadPostRequest) => {
+    console.log(isHeaderClick);
     console.log(data); // 제출된 폼 데이터 출력
   };
 
+  useEffect(() => {
+    if (isHeaderClick) {
+      methods.handleSubmit(onSubmit)();
+    }
+    return () => {
+      setIsHeaderClick(false);
+    };
+  }, [isHeaderClick, methods, onSubmit, setIsHeaderClick]);
+
   return (
     <FormProvider {...methods}>
-      <UploadForm onSubmit={onSubmit} />
+      <UploadForm />
     </FormProvider>
   );
 }

--- a/src/components/pages/UploadPage.tsx
+++ b/src/components/pages/UploadPage.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { FormProvider, useForm } from 'react-hook-form';
+
+import { IUploadPostRequest } from '@/api/types/post';
+import UploadForm from '@/components/common/form/upload-form/UploadForm';
+
+export default function UploadPage() {
+  const methods = useForm({
+    defaultValues: {
+      post: {
+        content: '',
+        image: '',
+      },
+    },
+  });
+
+  const onSubmit = (data: IUploadPostRequest) => {
+    console.log(data); // 제출된 폼 데이터 출력
+  };
+
+  return (
+    <FormProvider {...methods}>
+      <UploadForm onSubmit={onSubmit} />
+    </FormProvider>
+  );
+}

--- a/src/components/pages/UploadPage.tsx
+++ b/src/components/pages/UploadPage.tsx
@@ -6,9 +6,11 @@ import { FormProvider, useForm } from 'react-hook-form';
 import { IUploadPostRequest } from '@/api/types/post';
 import UploadForm from '@/components/common/form/upload-form/UploadForm';
 import { useHeaderContext } from '@/context/provider/headerContext';
+import useUploadPost from '@/hooks/queries/upload/useUploadPost';
 
 export default function UploadPage() {
   const { isHeaderClick, setIsHeaderClick } = useHeaderContext();
+  const { mutate: uploadPost } = useUploadPost();
   const methods = useForm({
     defaultValues: {
       post: {
@@ -21,6 +23,7 @@ export default function UploadPage() {
   const onSubmit = (data: IUploadPostRequest) => {
     console.log(isHeaderClick);
     console.log(data); // 제출된 폼 데이터 출력
+    uploadPost(data);
   };
 
   useEffect(() => {

--- a/src/config/headerConfig.tsx
+++ b/src/config/headerConfig.tsx
@@ -55,7 +55,7 @@ export const headerConfig: Record<string, IHeaderConfig> = {
   '/upload': {
     LeftIcon: BackArrow,
     RightButton: CustomButton,
-    rightButtonProps: { color: 'primary', size: 'ms', children: '저장' },
+    rightButtonProps: { color: 'primary', size: 'ms', children: '업로드' },
   },
   '/add-product': {
     LeftIcon: BackArrow,

--- a/src/context/provider/headerContext.tsx
+++ b/src/context/provider/headerContext.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { createContext, useState, ReactNode, useMemo, useContext } from 'react';
+
+interface IHeaderContext {
+  isHeaderClick: boolean;
+  setIsHeaderClick: (value: boolean) => void;
+}
+
+export const HeaderContext = createContext<IHeaderContext | undefined>(
+  undefined,
+);
+
+export function HeaderProvider({ children }: { children: ReactNode }) {
+  const [isHeaderClick, setIsHeaderClick] = useState(false);
+
+  const value = useMemo(
+    () => ({ isHeaderClick, setIsHeaderClick }),
+    [isHeaderClick],
+  );
+
+  return (
+    <HeaderContext.Provider value={value}>{children}</HeaderContext.Provider>
+  );
+}
+
+export const useHeaderContext = () => {
+  const context = useContext(HeaderContext);
+
+  if (!context) {
+    throw new Error('useHeaderContext must be used within a HeaderProvider');
+  }
+  return context;
+};

--- a/src/context/provider/index.tsx
+++ b/src/context/provider/index.tsx
@@ -1,0 +1,7 @@
+import { HeaderProvider } from './headerContext';
+
+function ContextProvider({ children }: { children: React.ReactNode }) {
+  return <HeaderProvider>{children}</HeaderProvider>;
+}
+
+export default ContextProvider;

--- a/src/hooks/queries/comment/useCommentList.ts
+++ b/src/hooks/queries/comment/useCommentList.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { useQuery } from '@tanstack/react-query';
 
-import { commentList } from '@/api/apiRequests/post';
+import { commentList } from '@/api/apiRequests/comment';
 
 function useCommentList(
   postId: string,

--- a/src/hooks/queries/comment/useCreateComment.ts
+++ b/src/hooks/queries/comment/useCreateComment.ts
@@ -1,7 +1,7 @@
 import { useMutation } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 
-import { createComment } from '@/api/apiRequests/post';
+import { createComment } from '@/api/apiRequests/comment';
 import { ICommentResponse, ICommentRequest } from '@/api/types/comment';
 
 function useCreateComment() {

--- a/src/hooks/queries/upload/useUploadPost.ts
+++ b/src/hooks/queries/upload/useUploadPost.ts
@@ -1,0 +1,23 @@
+import { useMutation } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+
+import { uploadPost } from '@/api/apiRequests/uploadPost';
+import { IPostDetail, IUploadPostRequest } from '@/api/types/post';
+
+function useUploadPost() {
+  const onSuccess = () => {
+    console.log('success');
+  };
+
+  const onError = (error: AxiosError) => {
+    console.error(error);
+  };
+
+  return useMutation<IPostDetail, AxiosError, IUploadPostRequest>({
+    mutationFn: uploadPost,
+    onSuccess,
+    onError,
+  });
+}
+
+export default useUploadPost;


### PR DESCRIPTION
## 📍 PR 타입

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제한 경우
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

</br>

## 🖇️ 반영 브랜치

<!-- ex) feat/login -> dev -->
page/feature/upload -> main

</br>

## 🛠️ 작업 내용

<!-- 어떤 작업을 했는지 -->
1. upload post api 요청 함수 구현
2. useUploadPost 쿼리훅 작성
3. Upload 페이지 react-hook-form 적용
4. headerContext 제작
5. header에서 버튼 클릭시 isHeaderClick을 true로 변경
6. isHeaderClick가 true라면 onSubmit이 실행되도록 작성
7. onSubmit 함수를 useCallback으로 메모이제이션

</br>

## 💣 이슈

<!-- 작업 시 이슈 -->
1. 문제 원인
onSubmit 함수가 컴포넌트 렌더링마다 새롭게 생성되고, useEffect의 의존성 배열에 포함되므로, 불필요한 재실행이 발생.

2. 해결 방법
useCallback을 사용하여 onSubmit 함수를 메모이제이션하면, onSubmit은 의존성 배열에 지정된 값이 변경될 때만 새롭게 생성

3. 주요 변경 사항
onSubmit을 useCallback으로 감싸기: onSubmit이 useEffect의 의존성 배열에 포함될 때, isHeaderClick이 변경되지 않는 한 새롭게 생성되지 않음.

4. 경고 해결 후 코드 흐름
Header에서 setIsHeaderClick(true) 호출.
UploadPage의 useEffect가 isHeaderClick의 변화를 감지.
methods.handleSubmit(onSubmit)이 실행되어 폼 데이터를 검증 후 onSubmit 호출.
onSubmit에서 데이터를 출력하거나 API 호출 수행.
useEffect의 cleanup 함수로 isHeaderClick 상태 초기화.

5. 결과
onSubmit이 불필요하게 재생성되지 않으며, useEffect가 의도한 대로 동작.
ESLint 경고(eslint-react-hooks/exhaustive-deps)가 제거.
React Hook 규칙을 준수하여 가독성과 유지보수성이 향상.

## 📕 참고 자료
https://velog.io/@velopert/react-context-tutorial
