### PR TITLE
페이지 UI: 게시글 업로드

### DIFF
--- a/public/assets/icons/icon-upload-file.svg
+++ b/public/assets/icons/icon-upload-file.svg
@@ -1,0 +1,6 @@
+<svg width="50" height="50" viewBox="0 0 50 50" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="25" cy="25" r="25" fill="#F26E22"/>
+<path d="M33.1667 14.5H16.8333C15.5447 14.5 14.5 15.5447 14.5 16.8333V33.1667C14.5 34.4553 15.5447 35.5 16.8333 35.5H33.1667C34.4553 35.5 35.5 34.4553 35.5 33.1667V16.8333C35.5 15.5447 34.4553 14.5 33.1667 14.5Z" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M20.9165 22.6667C21.883 22.6667 22.6665 21.8832 22.6665 20.9167C22.6665 19.9502 21.883 19.1667 20.9165 19.1667C19.95 19.1667 19.1665 19.9502 19.1665 20.9167C19.1665 21.8832 19.95 22.6667 20.9165 22.6667Z" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M35.5002 28.5L29.6668 22.6667L16.8335 35.5" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,6 +8,8 @@
   --background-start-rgb: 214, 219, 220;
   --background-end-rgb: 255, 255, 255;
   --primary-100: #f26e22;
+  /* w, h */
+  --header-height: 48px;
 }
 
 /* 다크 모드 */
@@ -66,6 +68,12 @@
 
 /* 작은 스타일 단위(유틸리티 클래스)를 정의. 필요에 따라 여러 곳에서 조합하여 사용 */
 @layer utilities {
+  .h-header {
+    height: var(--header-height);
+  }
+  .h-calc-header-screen {
+    height: calc(100vh - var(--header-height));
+  }
   .text-balance {
     text-wrap: balance;
   }

--- a/src/components/common/form/preview-image/PreviewImage.tsx
+++ b/src/components/common/form/preview-image/PreviewImage.tsx
@@ -1,0 +1,42 @@
+import classNames from 'classnames';
+import Image from 'next/image';
+
+import IconButton from '@/components/common/button/IconButton';
+
+interface IPreviewImageProps {
+  className: string;
+  previewUrl: string;
+  onClick: () => void;
+}
+
+export default function PreviewImage({
+  className,
+  previewUrl,
+  onClick,
+}: IPreviewImageProps) {
+  return (
+    <article className={classNames('relative', className)}>
+      <div className="relative h-full w-full overflow-hidden rounded-10px">
+        <Image
+          src={previewUrl}
+          alt="업로드 이미지 미리보기"
+          priority // LCP 최적화
+          fill
+          className="object-cover"
+        />
+      </div>
+      <IconButton
+        label="삭제 버튼"
+        className="absolute right-6px top-6px"
+        onClick={onClick}
+      >
+        <Image
+          src="/assets/icons/x.svg"
+          alt="삭제 아이콘 이미지"
+          width={22}
+          height={22}
+        />
+      </IconButton>
+    </article>
+  );
+}

--- a/src/components/common/form/upload-form/UploadForm.tsx
+++ b/src/components/common/form/upload-form/UploadForm.tsx
@@ -3,6 +3,8 @@ import Image from 'next/image';
 import { useFormContext } from 'react-hook-form';
 
 import { IUploadPostRequest } from '@/api/types/post';
+import PreviewImage from '@/components/common/form/preview-image/PreviewImage';
+import { usePreviewImage } from '@/hooks/usePreviewImage';
 
 interface IUploadFormProps {
   className?: string;
@@ -11,6 +13,7 @@ interface IUploadFormProps {
 export default function UploadForm({ className }: IUploadFormProps) {
   // useFormContext의 타입 지정
   const { register } = useFormContext<IUploadPostRequest>();
+  const { preview, addImage, deleteImage } = usePreviewImage();
 
   return (
     <form className={classNames('flex flex-col gap-4', className)}>
@@ -20,6 +23,14 @@ export default function UploadForm({ className }: IUploadFormProps) {
         className="scrollbar-hidden w-full resize-none text-14px focus:outline-none"
         rows={1} // 최소 높이
       />
+      {/* TODO: 여러개 이미지 처리하기 */}
+      {preview && (
+        <PreviewImage
+          previewUrl={preview}
+          onClick={deleteImage}
+          className="h-56"
+        />
+      )}
       <label
         htmlFor="postImage"
         className="relative mt-auto h-12 w-12 shrink-0 cursor-pointer self-end"
@@ -37,6 +48,7 @@ export default function UploadForm({ className }: IUploadFormProps) {
         type="file"
         id="postImage"
         className="hidden"
+        onChange={addImage}
       />
     </form>
   );

--- a/src/components/common/form/upload-form/UploadForm.tsx
+++ b/src/components/common/form/upload-form/UploadForm.tsx
@@ -1,21 +1,42 @@
+import classNames from 'classnames';
+import Image from 'next/image';
 import { useFormContext } from 'react-hook-form';
 
 import { IUploadPostRequest } from '@/api/types/post';
 
-export default function UploadForm() {
+interface IUploadFormProps {
+  className?: string;
+}
+
+export default function UploadForm({ className }: IUploadFormProps) {
   // useFormContext의 타입 지정
   const { register } = useFormContext<IUploadPostRequest>();
 
   return (
-    <form>
-      <input
+    <form className={classNames('flex flex-col gap-4', className)}>
+      <textarea
         {...register('post.content', { required: '게시글을 입력해주세요.' })}
-        placeholder="게시글 입력하기"
+        placeholder="게시글 입력하기..."
+        className="scrollbar-hidden w-full resize-none text-14px focus:outline-none"
+        rows={1} // 최소 높이
       />
+      <label
+        htmlFor="postImage"
+        className="relative mt-auto h-12 w-12 shrink-0 cursor-pointer self-end"
+      >
+        <Image
+          src="/assets/icons/icon-upload-file.svg"
+          alt="사진 첨부 아이콘"
+          fill
+          className="object-cover"
+        />
+      </label>
       <input
         {...register('post.image')}
         accept="image/jpg, image/jpeg, image/png, image/gif"
         type="file"
+        id="postImage"
+        className="hidden"
       />
     </form>
   );

--- a/src/components/common/form/upload-form/UploadForm.tsx
+++ b/src/components/common/form/upload-form/UploadForm.tsx
@@ -4,6 +4,7 @@ import { useFormContext } from 'react-hook-form';
 
 import { IUploadPostRequest } from '@/api/types/post';
 import PreviewImage from '@/components/common/form/preview-image/PreviewImage';
+import { useAutoResizeHeight } from '@/hooks/useAutoResizeHeight';
 import { usePreviewImage } from '@/hooks/usePreviewImage';
 
 interface IUploadFormProps {
@@ -14,6 +15,8 @@ export default function UploadForm({ className }: IUploadFormProps) {
   // useFormContext의 타입 지정
   const { register } = useFormContext<IUploadPostRequest>();
   const { preview, addImage, deleteImage } = usePreviewImage();
+  const { elementRef, resizeToFitContent } =
+    useAutoResizeHeight<HTMLTextAreaElement>();
 
   return (
     <form className={classNames('flex flex-col gap-4', className)}>
@@ -21,6 +24,8 @@ export default function UploadForm({ className }: IUploadFormProps) {
         {...register('post.content', { required: '게시글을 입력해주세요.' })}
         placeholder="게시글 입력하기..."
         className="scrollbar-hidden w-full resize-none text-14px focus:outline-none"
+        ref={elementRef}
+        onInput={resizeToFitContent}
         rows={1} // 최소 높이
       />
       {/* TODO: 여러개 이미지 처리하기 */}

--- a/src/components/common/header/withHeader.tsx
+++ b/src/components/common/header/withHeader.tsx
@@ -18,7 +18,7 @@ export default function withHeader(
 ) {
   return function WrappedComponent() {
     return (
-      <header className="flex items-center justify-between border-b-1 px-4 py-2 text-24px">
+      <header className="h-header flex items-center justify-between border-b-1 px-4 text-24px">
         <div className="flex items-center space-x-4">
           {LeftIcon && (
             <button

--- a/src/components/pages/UploadPage.tsx
+++ b/src/components/pages/UploadPage.tsx
@@ -5,6 +5,7 @@ import { FormProvider, useForm } from 'react-hook-form';
 
 import { IUploadPostRequest } from '@/api/types/post';
 import UploadForm from '@/components/common/form/upload-form/UploadForm';
+import UserImage from '@/components/common/post-item/user-card/UserImage';
 import { useHeaderContext } from '@/context/provider/headerContext';
 import useUploadPost from '@/hooks/queries/upload/useUploadPost';
 
@@ -40,7 +41,10 @@ export default function UploadPage() {
 
   return (
     <FormProvider {...methods}>
-      <UploadForm />
+      <main className="h-calc-header-screen flex gap-[13px] p-4">
+        <UserImage className="shadow-test1" />
+        <UploadForm className="h-full flex-grow" />
+      </main>
     </FormProvider>
   );
 }

--- a/src/hooks/useAutoResizeHeight.ts
+++ b/src/hooks/useAutoResizeHeight.ts
@@ -1,0 +1,15 @@
+import { useRef, useCallback } from 'react';
+
+export function useAutoResizeHeight<T extends HTMLElement>() {
+  const elementRef = useRef<T>(null);
+
+  const resizeToFitContent = useCallback(() => {
+    const element = elementRef.current;
+    if (element) {
+      element.style.height = 'auto'; // 높이 초기화
+      element.style.height = `${element.scrollHeight}px`; // 콘텐츠에 따라 높이 조정
+    }
+  }, []);
+
+  return { elementRef, resizeToFitContent };
+}

--- a/src/hooks/usePreviewImage.ts
+++ b/src/hooks/usePreviewImage.ts
@@ -1,0 +1,26 @@
+import { useState } from 'react';
+
+export function usePreviewImage() {
+  const [preview, setPreview] = useState<string | null>(null);
+
+  const addImage = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file) {
+      const reader = new FileReader();
+      reader.onload = () => {
+        setPreview(reader.result as string); // 미리보기 이미지 설정
+      };
+      reader.readAsDataURL(file); // 파일 객체를 읽어 base64 형태의 문자열로 변환
+    }
+  };
+
+  const deleteImage = () => {
+    setPreview(null);
+  };
+
+  return {
+    preview,
+    addImage,
+    deleteImage,
+  };
+}


### PR DESCRIPTION
## 📍 PR 타입

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제한 경우
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

</br>

## 🖇️ 반영 브랜치

<!-- ex) feat/login -> dev -->
page-ui-upload

</br>

## 🛠️ 작업 내용

<!-- 어떤 작업을 했는지 -->
- UploadForm 컴포넌트 UI 구현(UploadForm은 UI 로직만 처리하고, 비즈니스 로직은 훅으로 분리)
- 이미지 파일 추가시 보여줄 PreviewImage 컴포넌트(이미지 미리보기) 구현
- 이미지 업로드와 관련된 모든 비즈니스 로직을 처리하는 usePreviewImage 훅 생성
- DOM 요소의 높이를 자동 조정하도록 추상화한 useAutoResizeHeight 훅 생성

</br>

## 💣 이슈

<!-- 작업 시 이슈 -->
onInput 주요 특징
	1.	트리거 조건:
	•	사용자가 텍스트를 입력하거나 삭제할 때 발생.
	•	텍스트를 복사(Ctrl+C), 붙여넣기(Ctrl+V), 잘라내기(Ctrl+X) 할 때도 발생.
	•	JavaScript로 값을 변경하는 경우엔 발생하지 않음.
	2.	사용 가능한 요소:
	•	input, textarea, div[contenteditable="true"] 등 사용자 입력이 가능한 요소에서 사용 가능.
	3.	onChange와의 차이점:
	•	onInput: 사용자가 값을 입력할 때마다 즉시 발생.
	•	onChange: 사용자가 입력을 완료하고 필드를 벗어났을 때(블러 시점) 발생.
	
input의 높이를 실시간으로 변경하는 로직은 입력할 때마다 DOM에 접근하여 스타일을 업데이트하기 때문에, 입력이 많아지거나 동작이 복잡할 경우 성능 저하를 유발할 수 있음. 특히 매우 긴 텍스트나 빠르게 입력하는 경우 성능 문제가 두드러질 수 있음.
-> TODO: debounce 또는 throttle 적용하여 입력 이벤트 호출을 제한하여 DOM 조작 빈도를 줄이기