### PR TITLE
리팩토링: 게시글 업로드

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "eslint-config-prettier": "^9.1.0",
     "framer-motion": "^11.3.31",
     "js-cookie": "^3.0.5",
+    "lodash": "^4.17.21",
     "next": "14.2.6",
     "prettier": "^3.3.3",
     "react": "^18",

--- a/src/components/common/form/upload-form/UploadForm.tsx
+++ b/src/components/common/form/upload-form/UploadForm.tsx
@@ -15,17 +15,22 @@ export default function UploadForm({ className }: IUploadFormProps) {
   // useFormContext의 타입 지정
   const { register } = useFormContext<IUploadPostRequest>();
   const { preview, addImage, deleteImage } = usePreviewImage();
-  const { elementRef, resizeToFitContent } =
-    useAutoResizeHeight<HTMLTextAreaElement>();
+  const { elementRef, throttledResize } =
+    useAutoResizeHeight<HTMLTextAreaElement>(200);
 
   return (
     <form className={classNames('flex flex-col gap-4', className)}>
       <textarea
-        {...register('post.content', { required: '게시글을 입력해주세요.' })}
+        {...register('post.content', {
+          required: '게시글을 입력해주세요.',
+        })}
         placeholder="게시글 입력하기..."
         className="scrollbar-hidden w-full resize-none text-14px focus:outline-none"
-        ref={elementRef}
-        onInput={resizeToFitContent}
+        ref={(e) => {
+          register('post.content').ref(e); // React Hook Form의 ref
+          elementRef.current = e; // useAutoResizeHeight의 ref
+        }}
+        onInput={throttledResize}
         rows={1} // 최소 높이
       />
       {/* TODO: 여러개 이미지 처리하기 */}

--- a/src/hooks/useAutoResizeHeight.ts
+++ b/src/hooks/useAutoResizeHeight.ts
@@ -1,15 +1,30 @@
-import { useRef, useCallback } from 'react';
+import { throttle } from 'lodash';
+import { useRef, useCallback, useMemo, useEffect } from 'react';
 
-export function useAutoResizeHeight<T extends HTMLElement>() {
-  const elementRef = useRef<T>(null);
+export function useAutoResizeHeight<T extends HTMLElement>(throttleTime = 100) {
+  const elementRef = useRef<T | null>(null);
 
   const resizeToFitContent = useCallback(() => {
     const element = elementRef.current;
     if (element) {
       element.style.height = 'auto'; // 높이 초기화
-      element.style.height = `${element.scrollHeight}px`; // 콘텐츠에 따라 높이 조정
+      element.style.height = `${element.scrollHeight}px`; // 콘텐츠에  조정
     }
   }, []);
 
-  return { elementRef, resizeToFitContent };
+  // Throttled function 생성
+  const throttledResize = useMemo(
+    () => throttle(resizeToFitContent, throttleTime),
+    [resizeToFitContent, throttleTime],
+  );
+
+  // Cleanup: Throttle 함수 정리
+  useEffect(() => {
+    return () => {
+      console.log('cl');
+      throttledResize.cancel(); // 메모리 누수 방지
+    };
+  }, [throttledResize]);
+
+  return { elementRef, throttledResize };
 }


### PR DESCRIPTION
## 📍 PR 타입

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제한 경우
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [x] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

</br>

## 🖇️ 반영 브랜치

<!-- ex) feat/login -> dev -->
page/refactor/upload

</br>

## 🛠️ 작업 내용

<!-- 어떤 작업을 했는지 -->
- lodash 설치
- useMemo로 throttle 캐싱, useEffect로 cleanup을 처리
- 

</br>

## 💣 이슈

<!-- 작업 시 이슈 -->
- ref를 중복 할당시에 React Hook Form의 폼 제출이 안되는 오류 발생
-> 
React Hook Form과 외부 훅이 충돌 없이 같은 textarea DOM 요소를 참조하도록 설계.
register는 React Hook Form의 입력값 추적 기능을 유지하고, elementRef는 외부 로직(useAutoResizeHeight)을 위한 DOM 접근을 제공.
	1.	ref는 DOM 요소(textarea)가 렌더링될 때 호출됩니다.
	2.	e는 현재 DOM 요소(textarea)를 참조합니다.
	3.	register('post.content').ref(e)
	•	React Hook Form에 해당 DOM 요소를 등록.
	•	React Hook Form이 입력값을 추적하고 관리.
	4.	elementRef.current = e
	•	외부 훅(useAutoResizeHeight)에서 동일한 DOM 요소를 참조.
	•	높이 조정 등의 동작을 위해 DOM 접근을 제공합니다.