### PR TITLE
페이지 기능: 팔로우/언팔로우 API 연결

### DIFF
--- a/src/api/apiRequests/follow.ts
+++ b/src/api/apiRequests/follow.ts
@@ -1,0 +1,20 @@
+import { deleteRequest, postRequest } from '@/api/requests';
+import { IFollowResponse } from '@/api/types/follow';
+
+/* --- 댓글 POST 요청 --- */
+export const follow = async (accountName: string) => {
+  const response = await postRequest<IFollowResponse>(
+    `/profile/${accountName}/follow`,
+  );
+
+  return response;
+};
+
+/* --- 댓글 DELETE 요청 --- */
+export const unfollow = async (accountName: string) => {
+  const response = await deleteRequest<IFollowResponse>(
+    `/profile/${accountName}/unfollow`,
+  );
+
+  return response;
+};

--- a/src/api/requests.ts
+++ b/src/api/requests.ts
@@ -12,7 +12,7 @@ export const getRequest = async <T>(
 };
 
 /* POST 요청 */
-export const postRequest = async <T, D>(
+export const postRequest = async <T, D = void>(
   url: string,
   data?: D,
   config?: AxiosRequestConfig,

--- a/src/api/types/follow.ts
+++ b/src/api/types/follow.ts
@@ -1,3 +1,7 @@
 import { IUserProfile } from './user';
 
 export type IFollowList = IUserProfile[];
+
+export interface IFollowResponse {
+  profile: IUserProfile;
+}

--- a/src/components/follow/FollowButton.tsx
+++ b/src/components/follow/FollowButton.tsx
@@ -1,0 +1,21 @@
+import { CustomButton } from '@/components/common/button';
+
+interface IFollowButtonProps {
+  isFollow: boolean;
+  onClick?: () => void;
+}
+
+export default function FollowButton({
+  isFollow,
+  onClick,
+}: IFollowButtonProps) {
+  return (
+    <CustomButton
+      onClick={onClick}
+      color={isFollow ? 'white' : 'primary'}
+      size="s"
+    >
+      {isFollow ? '취소' : '팔로우'}
+    </CustomButton>
+  );
+}

--- a/src/hooks/queries/follow/useFollow.ts
+++ b/src/hooks/queries/follow/useFollow.ts
@@ -1,0 +1,18 @@
+import { useMutation } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+
+import { follow } from '@/api/apiRequests/follow';
+import { IFollowResponse } from '@/api/types/follow';
+
+function useFollow() {
+  const onError = (error: AxiosError) => {
+    console.error(error);
+  };
+
+  return useMutation<IFollowResponse, AxiosError, { accountName: string }>({
+    mutationFn: ({ accountName }) => follow(accountName),
+    onError,
+  });
+}
+
+export default useFollow;

--- a/src/hooks/queries/follow/useUnFollow.ts
+++ b/src/hooks/queries/follow/useUnFollow.ts
@@ -1,0 +1,18 @@
+import { useMutation } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+
+import { unfollow } from '@/api/apiRequests/follow';
+import { IFollowResponse } from '@/api/types/follow';
+
+function useUnFollow() {
+  const onError = (error: AxiosError) => {
+    console.error(error);
+  };
+
+  return useMutation<IFollowResponse, AxiosError, { accountName: string }>({
+    mutationFn: ({ accountName }) => unfollow(accountName),
+    onError,
+  });
+}
+
+export default useUnFollow;


### PR DESCRIPTION
## 📍 PR 타입

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제한 경우
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

</br>

## 🖇️ 반영 브랜치

<!-- ex) feat/login -> dev -->
page/feature/follow/list

</br>

## 🛠️ 작업 내용

<!-- 어떤 작업을 했는지 -->
- 팔로우, 언팔로우 API 응답 타입 정의 및 API 요청 함수 구현
- 팔로우/언팔로우 API 요청 쿼리훅 작성
- 팔로우/취소 UI를 담당하는 FollowButton 컴포넌트 구현
- 팔로우/취소 시 버튼 UI와 해당 유저의 팔로우 상태를 변경하는 handleFollowClick 함수 구현
  - 주요 변경점
    1. 로컬 상태 관리
       - `useState`를 사용하여 각 사용자의 `isfollow` 상태를 관리.
       - 상태 키는 `accountname`을 사용하여 고유값으로 구분.
    2. 상태 반전 로직
       - 클릭 시 로컬 상태를 반전하여 즉시 UI 업데이트.
       - React Query 데이터를 수정하지 않으므로 UI만 변경.
    3. API 호출 분리
       - `follow`와 `unfollow` API 호출은 로컬 상태와 독립적으로 동작.
    4. UI 동기화
       - `userFollowStatus`에서 값을 먼저 확인하고, 값이 없을 경우 서버 값을 사용(`user.isfollow`).
  - 작동 방식
    1. 초기 렌더링
       - `user.isfollow` 값을 사용하여 초기 UI 렌더링.
    2. 버튼 클릭
       - `handleFollowClick` 함수가 호출되면서 `followState` 값이 업데이트.
       - `setFollowState`로 `isFollowed` 상태를 반전.
       - UI 즉시 변경.
    3. API 호출
       - 상태 업데이트와 별개로 `follow` 또는 `unfollow` API 호출.

</br>

## 💣 이슈

<!-- 작업 시 이슈 -->
postRequest 함수는 data와 config를 선택적으로 받을 수 있도록 정의되어 있었지만 TypeScript에서는 postRequest가 두 개의 타입 인수를 받도록 정의된 상황에서 하나만 전달하면 에러가 발생.
->
`D`는 제네릭 타입으로, `postRequest` 함수의 `data` 매개변수 타입을 지정함. 
`D = void`는 TypeScript에서 제네릭 타입에 기본값을 설정하는 방법으로 `void`는 **값이 없음을 명시적으로 나타내는 타입**. 
결론적으로 `data`를 제공하지 않아도 오류가 발생하지 않음.
