### PR TITLE
리팩토링: 게시글 업로드 폼

### DIFF
--- a/src/app/(private)/upload/page.tsx
+++ b/src/app/(private)/upload/page.tsx
@@ -1,5 +1,5 @@
-import UploadPage from '@/components/pages/UploadPage';
+import PostUploadPage from '@/components/pages/PostUploadPage';
 
 export default function page() {
-  return <UploadPage />;
+  return <PostUploadPage />;
 }

--- a/src/components/common/form/upload-form/UploadForm.tsx
+++ b/src/components/common/form/upload-form/UploadForm.tsx
@@ -13,10 +13,20 @@ interface IUploadFormProps {
 
 export default function UploadForm({ className }: IUploadFormProps) {
   // useFormContext의 타입 지정
-  const { register } = useFormContext<IUploadPostRequest>();
+  const { setValue, register } = useFormContext<IUploadPostRequest>();
+
   const { preview, addImage, deleteImage } = usePreviewImage();
   const { elementRef, throttledResize } =
     useAutoResizeHeight<HTMLTextAreaElement>(200);
+
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const imageFile = e.target.files?.[0]; // 첫 번째 파일만 선택
+    // TODO: 이미지 파일 API 명세에 맞게 수정할 것
+    if (imageFile) {
+      setValue('post.image', imageFile.name); // React Hook Form 상태 업데이트
+      addImage(imageFile);
+    }
+  };
 
   return (
     <form className={classNames('flex flex-col gap-4', className)}>
@@ -42,8 +52,7 @@ export default function UploadForm({ className }: IUploadFormProps) {
         />
       )}
       <ImageInput
-        {...register('post.image')}
-        onChange={addImage}
+        onChange={handleImageChange}
         className="mt-auto shrink-0 self-end"
       />
     </form>

--- a/src/components/pages/PostUploadPage.tsx
+++ b/src/components/pages/PostUploadPage.tsx
@@ -23,21 +23,18 @@ export default function PostUploadPage() {
 
   const onSubmit = useCallback(
     (data: IUploadPostRequest) => {
-      console.log('isHeaderClick:', isHeaderClick);
       console.log('Data:', data);
       uploadPost(data);
     },
-    [isHeaderClick, uploadPost],
+    [uploadPost],
   );
 
   useEffect(() => {
     console.log('useEffect:', isHeaderClick);
     if (isHeaderClick) {
       methods.handleSubmit(onSubmit)();
-    }
-    return () => {
       setIsHeaderClick(false);
-    };
+    }
   }, [isHeaderClick, methods, onSubmit, setIsHeaderClick]);
 
   return (

--- a/src/components/pages/PostUploadPage.tsx
+++ b/src/components/pages/PostUploadPage.tsx
@@ -9,7 +9,7 @@ import UserImage from '@/components/common/post-item/user-card/UserImage';
 import { useHeaderContext } from '@/context/provider/HeaderContext';
 import useUploadPost from '@/queries/upload/useUploadPost';
 
-export default function UploadPage() {
+export default function PostUploadPage() {
   const { isHeaderClick, setIsHeaderClick } = useHeaderContext();
   const { mutate: uploadPost } = useUploadPost();
   const methods = useForm({
@@ -31,6 +31,7 @@ export default function UploadPage() {
   );
 
   useEffect(() => {
+    console.log('useEffect:', isHeaderClick);
     if (isHeaderClick) {
       methods.handleSubmit(onSubmit)();
     }
@@ -40,11 +41,11 @@ export default function UploadPage() {
   }, [isHeaderClick, methods, onSubmit, setIsHeaderClick]);
 
   return (
-    <FormProvider {...methods}>
-      <main className="h-calc-header-screen flex gap-[13px] p-4">
+    <main className="h-calc-header-screen flex gap-[13px] p-4">
+      <FormProvider {...methods}>
         <UserImage className="shadow-test1" />
         <UploadForm className="h-full flex-grow" />
-      </main>
-    </FormProvider>
+      </FormProvider>
+    </main>
   );
 }

--- a/src/hooks/usePreviewImage.ts
+++ b/src/hooks/usePreviewImage.ts
@@ -3,15 +3,10 @@ import { useState } from 'react';
 export function usePreviewImage() {
   const [preview, setPreview] = useState<string | null>(null);
 
-  const addImage = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0];
-    if (file) {
-      const reader = new FileReader();
-      reader.onload = () => {
-        setPreview(reader.result as string); // 미리보기 이미지 설정
-      };
-      reader.readAsDataURL(file); // 파일 객체를 읽어 base64 형태의 문자열로 변환
-    }
+  const addImage = (file: File) => {
+    const reader = new FileReader();
+    reader.onload = () => setPreview(reader.result as string);
+    reader.readAsDataURL(file);
   };
 
   const deleteImage = () => {


### PR DESCRIPTION
## 📍 PR 타입

- [ ] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 버그 수정
- [x] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제한 경우
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

</br>

## 🖇️ 반영 브랜치

<!-- ex) feat/login -> dev -->
page/refactor/upload -> main
</br>

## 🛠️ 작업 내용

<!-- 어떤 작업을 했는지 -->
- PostUploadPage로 컴포넌트명 변경
- ImageInput에 onChange 핸들러를 명시적으로 구현해 파일을 처리하고 setValue를 호출하여 React Hook Form의 상태를 업데이트
- usePreviewImage훅의 addImage함수 매개변수를 이벤트 대신 파일을 받도록 수정하여 인터페이스 단순화. 

</br>

## 💣 이슈

<!-- 작업 시 이슈 -->
React Hook Form의 register와 이미지 입력 컴포넌트(ImageInput) 간에 데이터가 제대로 연결되지 않아 post.image가 빈 문자열("")로 나옴
-> ImageInput의 onChange에 previewImage를 업데이트 해주는 함수만 전달했기 때문
-> Upload 컴포넌트에서 setValue를 통해 image를 제대로 업데이트