### PR TITLE
리팩토링: 업로드 폼

### DIFF
--- a/src/components/common/form/auth-form/FieldsLayout.tsx
+++ b/src/components/common/form/auth-form/FieldsLayout.tsx
@@ -41,7 +41,6 @@ export default function FieldsLayout({
             key={`${prefix}.${name}`}
             {...register(`${prefix}.${name}`, field.validation)}
             isClearable
-            variant="underlined"
             type={inputType}
             label={field.label}
             placeholder={field.placeholder}

--- a/src/components/common/form/upload-form/ImageUploadField.tsx
+++ b/src/components/common/form/upload-form/ImageUploadField.tsx
@@ -1,0 +1,56 @@
+import { useFormContext } from 'react-hook-form';
+
+import PreviewImage from '@/components/common/form/preview-image/PreviewImage';
+import ImageInput from '@/components/common/input/ImageInput';
+import { usePreviewImage } from '@/hooks/usePreviewImage';
+
+interface ImageUploadFieldProps {
+  name: string;
+  previewImageClassName?: string;
+  imageInputClassName?: string;
+  inputSize?: 's' | 'm';
+}
+
+export default function ImageUploadField({
+  name,
+  previewImageClassName,
+  imageInputClassName,
+  inputSize = 'm',
+}: ImageUploadFieldProps) {
+  const { setValue } = useFormContext();
+
+  const { preview, addImage, deleteImage } = usePreviewImage();
+
+  //   TODO: 이미지 삭제시 코드도 구현
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const imageFile = e.target.files?.[0];
+    if (imageFile) {
+      setValue('product.itemImage', imageFile.name);
+      addImage(imageFile);
+    }
+  };
+
+  return (
+    <>
+      {/* TODO preview 이미지 여러개일 때 css 구현 */}
+      {preview && (
+        <div className="h-full w-full">
+          {preview.map((url, i) => (
+            <PreviewImage
+              key={url}
+              previewUrl={url}
+              onClick={() => deleteImage(i)}
+              className={previewImageClassName}
+            />
+          ))}
+        </div>
+      )}
+      <ImageInput
+        name={name}
+        onChange={handleImageChange}
+        inputSize={inputSize}
+        className={imageInputClassName}
+      />
+    </>
+  );
+}

--- a/src/components/common/form/upload-form/ProductUploadForm.tsx
+++ b/src/components/common/form/upload-form/ProductUploadForm.tsx
@@ -1,12 +1,8 @@
-import { useFormContext } from 'react-hook-form';
-
-import ImageInput from '@/components/common/input/ImageInput';
 import Text from '@/components/common/text/Text';
 import { productFields } from '@/config/uploadFieldConfig';
-import { usePreviewImage } from '@/hooks/usePreviewImage';
 
+import ImageUploadField from './ImageUploadField';
 import FieldsLayout from '../auth-form/FieldsLayout';
-import PreviewImage from '../preview-image/PreviewImage';
 
 interface IProductUploadFormProps {
   className?: string;
@@ -15,18 +11,6 @@ interface IProductUploadFormProps {
 export default function ProductUploadForm({
   className,
 }: IProductUploadFormProps) {
-  const { setValue } = useFormContext();
-
-  const { preview, addImage, deleteImage } = usePreviewImage();
-
-  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const imageFile = e.target.files?.[0];
-    if (imageFile) {
-      setValue('product.image', imageFile.name);
-      addImage(imageFile);
-    }
-  };
-
   return (
     <form className={className}>
       <FieldsLayout fields={productFields} prefix="product">
@@ -34,17 +18,10 @@ export default function ProductUploadForm({
           이미지 등록
         </Text>
         <div className="relative h-[204px] w-full rounded-10px bg-gray-100">
-          {preview && (
-            <PreviewImage
-              previewUrl={preview}
-              onClick={deleteImage}
-              className="h-full"
-            />
-          )}
-          <ImageInput
+          <ImageUploadField
+            name="product.itemImage"
+            imageInputClassName="absolute bottom-3 right-3 z-10"
             inputSize="s"
-            className="absolute bottom-3 right-3 z-10"
-            onChange={handleImageChange}
           />
         </div>
       </FieldsLayout>

--- a/src/components/common/form/upload-form/UploadForm.tsx
+++ b/src/components/common/form/upload-form/UploadForm.tsx
@@ -2,10 +2,9 @@ import classNames from 'classnames';
 import { useFormContext } from 'react-hook-form';
 
 import { IUploadPostRequest } from '@/api/types/post';
-import PreviewImage from '@/components/common/form/preview-image/PreviewImage';
-import ImageInput from '@/components/common/input/ImageInput';
 import { useAutoResizeHeight } from '@/hooks/useAutoResizeHeight';
-import { usePreviewImage } from '@/hooks/usePreviewImage';
+
+import ImageUploadField from './ImageUploadField';
 
 interface IUploadFormProps {
   className?: string;
@@ -13,20 +12,10 @@ interface IUploadFormProps {
 
 export default function UploadForm({ className }: IUploadFormProps) {
   // useFormContext의 타입 지정
-  const { setValue, register } = useFormContext<IUploadPostRequest>();
+  const { register } = useFormContext<IUploadPostRequest>();
 
-  const { preview, addImage, deleteImage } = usePreviewImage();
   const { elementRef, throttledResize } =
     useAutoResizeHeight<HTMLTextAreaElement>(200);
-
-  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const imageFile = e.target.files?.[0]; // 첫 번째 파일만 선택
-    // TODO: 이미지 파일 API 명세에 맞게 수정할 것
-    if (imageFile) {
-      setValue('post.image', imageFile.name); // React Hook Form 상태 업데이트
-      addImage(imageFile);
-    }
-  };
 
   return (
     <form className={classNames('flex flex-col gap-4', className)}>
@@ -43,17 +32,10 @@ export default function UploadForm({ className }: IUploadFormProps) {
         onInput={throttledResize}
         rows={1} // 최소 높이
       />
-      {/* TODO: 여러개 이미지 처리하기 */}
-      {preview && (
-        <PreviewImage
-          previewUrl={preview}
-          onClick={deleteImage}
-          className="h-56"
-        />
-      )}
-      <ImageInput
-        onChange={handleImageChange}
-        className="mt-auto shrink-0 self-end"
+      <ImageUploadField
+        name="post.image"
+        previewImageClassName="h-56"
+        imageInputClassName="mt-auto shrink-0 self-end"
       />
     </form>
   );

--- a/src/components/common/input/ImageInput.tsx
+++ b/src/components/common/input/ImageInput.tsx
@@ -1,6 +1,5 @@
 import classNames from 'classnames';
 import Image from 'next/image';
-import { ForwardedRef, forwardRef } from 'react';
 
 type InputSize = 's' | 'm';
 type InputColor = 'primary-100' | 'gray-200';
@@ -30,53 +29,43 @@ const inputStyles: {
   },
 };
 
-const ImageInput = forwardRef(
-  (
-    {
-      inputSize = 'm',
-      color = 'primary-100',
-      id = 'imageFile',
-      accept = 'image/jpg, image/jpeg, image/png, image/gif',
-      className,
-      onChange,
-      ...inputProps
-    }: ImageInputProps,
-    ref: ForwardedRef<HTMLInputElement>,
-  ) => {
-    const size = inputStyles.sizes[inputSize];
+export default function ImageInput({
+  inputSize = 'm',
+  color = 'primary-100',
+  id = 'imageFile',
+  accept = 'image/jpg, image/jpeg, image/png, image/gif',
+  className,
+  ...inputProps
+}: ImageInputProps) {
+  const size = inputStyles.sizes[inputSize];
 
-    return (
-      <>
-        <label
-          htmlFor={id}
-          className={classNames(
-            'relative cursor-pointer rounded-full',
-            size.label,
-            inputStyles.colors[color],
-            className,
-          )}
-        >
-          <Image
-            src="/assets/icons/icon-image.svg"
-            alt="사진 첨부 아이콘"
-            priority
-            width={size.img}
-            height={size.img}
-            className="position-center"
-          />
-        </label>
-        <input
-          type="file"
-          ref={ref}
-          accept={accept}
-          className="hidden"
-          id={id}
-          onChange={onChange}
-          {...inputProps}
+  return (
+    <>
+      <label
+        htmlFor={id}
+        className={classNames(
+          'cursor-pointer rounded-full',
+          size.label,
+          inputStyles.colors[color],
+          className,
+        )}
+      >
+        <Image
+          src="/assets/icons/icon-image.svg"
+          alt="사진 첨부 아이콘"
+          priority
+          width={size.img}
+          height={size.img}
+          className="position-center"
         />
-      </>
-    );
-  },
-);
-
-export default ImageInput;
+      </label>
+      <input
+        type="file"
+        accept={accept}
+        className="hidden"
+        id={id}
+        {...inputProps}
+      />
+    </>
+  );
+}

--- a/src/components/common/input/UnderlineInput.tsx
+++ b/src/components/common/input/UnderlineInput.tsx
@@ -38,5 +38,6 @@ export const UnderlineInput = extendVariants(Input, {
   defaultVariants: {
     color: 'stone',
     size: 'full',
+    variant: 'underlined',
   },
 });

--- a/src/hooks/usePreviewImage.ts
+++ b/src/hooks/usePreviewImage.ts
@@ -1,16 +1,17 @@
 import { useState } from 'react';
 
 export function usePreviewImage() {
-  const [preview, setPreview] = useState<string | null>(null);
+  const [preview, setPreview] = useState<string[]>([]);
 
   const addImage = (file: File) => {
     const reader = new FileReader();
-    reader.onload = () => setPreview(reader.result as string);
+    reader.onload = () =>
+      setPreview((prev) => [...prev, reader.result as string]);
     reader.readAsDataURL(file);
   };
 
-  const deleteImage = () => {
-    setPreview(null);
+  const deleteImage = (index: number) => {
+    setPreview((prev) => prev.filter((_, i) => i !== index));
   };
 
   return {


### PR DESCRIPTION
## 📍 PR 타입

- [ ] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 버그 수정
- [x] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제한 경우
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

</br>

## 🖇️ 반영 브랜치

<!-- ex) feat/login -> dev -->
refactor/upload/form -> main

</br>

## 🛠️ 작업 내용

<!-- 어떤 작업을 했는지 -->
-  ImageInput forwardRef 제거(ref를 사용하지 않아도 되는 상황에서는 성능이나 유지보수 측면에서 제거하는게 적합하다고 판단)
- UploadForm에서 이미지 상태와 관련된 로직을 컴포넌트 외부로 추출하여 더 모듈화된 설계 구현(ImageUploadField)
- 이미지 삭제 시에 미리보기 뿐만 아니라 데이터에서도 삭제하는 로직 추가
- usePreview 훅에서 여러개의 이미지 처리를 위해 preview를 배열로 변경, 이미지 추가, 삭제 함수 수정

</br>

## 💣 이슈

<!-- 작업 시 이슈 -->
1. 다중 이미지 처리 시 css 구현 필요
2. 상품 업로드 시에는 단일 이미지 필요
3. 각종 Image 컴포넌트 통합이나 일관된 분리 필요
