### PR TITLE
페이지 기능: 회원가입 프로필 이미지 입력 구현

### DIFF
--- a/src/components/common/form/auth-form/ProfileFields.tsx
+++ b/src/components/common/form/auth-form/ProfileFields.tsx
@@ -3,25 +3,31 @@ import { useFormContext } from 'react-hook-form';
 import ImageInput from '@/components/common/input/ImageInput';
 import UserImage from '@/components/common/post-item/user-card/UserImage';
 import { profileFields } from '@/config/authFieldConfig';
-// import { usePreviewImage } from '@/hooks/usePreviewImage';
+import { usePreviewImage } from '@/hooks/usePreviewImage';
 
 import FieldsLayout from './FieldsLayout';
 
 export default function ProfileFields() {
-  const { register } = useFormContext();
-  // const { addImage } = usePreviewImage();
+  const { register, setValue } = useFormContext();
+  const { preview, addImage } = usePreviewImage(false);
 
-  //  const { addImage, deleteImage } = usePreviewImage();
-  // ImageInput 컴포넌트에서 image를 가져오면 UserImage에서 렌더링 되어야 함.
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const imageFile = e.target.files?.[0];
+    if (imageFile) {
+      setValue('user.image', imageFile.name);
+      addImage(imageFile);
+    }
+  };
 
   return (
     <FieldsLayout fields={profileFields}>
       <div className="relative">
-        <UserImage size="110px" link={false} />
+        <UserImage size="110px" link={false} src={preview[0]} />
         <ImageInput
-          {...register('user.image')}
           inputSize="s"
-          // onChange={addImage}
+          {...register('user.image', {
+            onChange: handleImageChange,
+          })}
           className="absolute bottom-0 right-0"
         />
       </div>

--- a/src/components/common/form/auth-form/ProfileFields.tsx
+++ b/src/components/common/form/auth-form/ProfileFields.tsx
@@ -16,13 +16,13 @@ export default function ProfileFields() {
 
   return (
     <FieldsLayout fields={profileFields}>
-      <div className="flex h-[110px] w-[110px] items-end">
-        <UserImage size="inherit" />
+      <div className="relative">
+        <UserImage size="110px" link={false} />
         <ImageInput
           {...register('user.image')}
           inputSize="s"
           // onChange={addImage}
-          className="shrink-0 -translate-x-full"
+          className="absolute bottom-0 right-0"
         />
       </div>
     </FieldsLayout>

--- a/src/components/common/input/ImageInput.tsx
+++ b/src/components/common/input/ImageInput.tsx
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import Image from 'next/image';
+import { forwardRef } from 'react';
 
 type InputSize = 's' | 'm';
 type InputColor = 'primary-100' | 'gray-200';
@@ -29,43 +30,53 @@ const inputStyles: {
   },
 };
 
-export default function ImageInput({
-  inputSize = 'm',
-  color = 'primary-100',
-  id = 'imageFile',
-  accept = 'image/jpg, image/jpeg, image/png, image/gif',
-  className,
-  ...inputProps
-}: ImageInputProps) {
-  const size = inputStyles.sizes[inputSize];
+const ImageInput = forwardRef<HTMLInputElement, ImageInputProps>(
+  (
+    {
+      inputSize = 'm',
+      color = 'primary-100',
+      id = 'imageFile',
+      accept = 'image/jpg, image/jpeg, image/png, image/gif',
+      className,
+      ...inputProps
+    },
+    ref,
+  ) => {
+    const size = inputStyles.sizes[inputSize];
 
-  return (
-    <>
-      <label
-        htmlFor={id}
-        className={classNames(
-          'cursor-pointer rounded-full',
-          size.label,
-          inputStyles.colors[color],
-          className,
-        )}
-      >
-        <Image
-          src="/assets/icons/icon-image.svg"
-          alt="사진 첨부 아이콘"
-          priority
-          width={size.img}
-          height={size.img}
-          className="position-center"
+    return (
+      <>
+        <label
+          htmlFor={id}
+          className={classNames(
+            'cursor-pointer rounded-full',
+            size.label,
+            inputStyles.colors[color],
+            className,
+          )}
+        >
+          <Image
+            src="/assets/icons/icon-image.svg"
+            alt="사진 첨부 아이콘"
+            priority
+            width={size.img}
+            height={size.img}
+            className="position-center"
+          />
+        </label>
+        <input
+          type="file"
+          accept={accept}
+          className="hidden"
+          id={id}
+          ref={ref}
+          {...inputProps}
         />
-      </label>
-      <input
-        type="file"
-        accept={accept}
-        className="hidden"
-        id={id}
-        {...inputProps}
-      />
-    </>
-  );
-}
+      </>
+    );
+  },
+);
+
+// React DevTools에서 디버깅할 때 이름이 표시되도록 displayName 설정
+ImageInput.displayName = 'ImageInput';
+export default ImageInput;

--- a/src/components/common/post-item/user-card/UserImage.tsx
+++ b/src/components/common/post-item/user-card/UserImage.tsx
@@ -6,6 +6,7 @@ import CustomImage from '@/components/common/custom-image/CustomImage';
 
 interface IUserImageProps {
   user?: IUserProfileBase | IUserProfile;
+  src?: string;
   size?: '42px' | '50px' | '110px' | '36px' | 'inherit';
   link?: boolean;
   className?: string;
@@ -21,6 +22,7 @@ const sizeMap: Record<string, string> = {
 
 export default function UserImage({
   user,
+  src,
   size = '42px',
   link = true,
   className,
@@ -29,8 +31,8 @@ export default function UserImage({
 
   const Avatar = (
     <CustomImage
-      imageSrc={user?.image || '/assets/icons/basic-profile-img-.svg'}
-      alt={`${user?.username} 프로필 이미지`}
+      imageSrc={src || user?.image || '/assets/icons/basic-profile-img-.svg'}
+      alt={`${user?.username || ''} 프로필 이미지`}
       className={avatarClassNames}
     />
   );

--- a/src/components/common/post-item/user-card/UserImage.tsx
+++ b/src/components/common/post-item/user-card/UserImage.tsx
@@ -1,41 +1,39 @@
 import classNames from 'classnames';
-import Image from 'next/image';
 import Link from 'next/link';
 
 import { IUserProfile, IUserProfileBase } from '@/api/types/user';
+import CustomImage from '@/components/common/custom-image/CustomImage';
 
 interface IUserImageProps {
   user?: IUserProfileBase | IUserProfile;
   size?: '42px' | '50px' | '110px' | '36px' | 'inherit';
-  type?: 'link' | 'disabled';
+  link?: boolean;
   className?: string;
 }
+
+const sizeMap: Record<string, string> = {
+  '42px': 'h-[42px] w-[42px]',
+  '50px': 'h-[50px] w-[50px]',
+  '110px': 'h-[110px] w-[110px]',
+  '36px': 'h-[36px] w-[36px]',
+  inherit: 'h-full w-full',
+};
 
 export default function UserImage({
   user,
   size = '42px',
-  type = 'disabled',
+  link = true,
   className,
 }: IUserImageProps) {
-  const herf = type === 'link' ? `/profile/:${user?.accountname}` : '#';
+  const avatarClassNames = classNames(sizeMap[size], 'rounded-full', className);
 
-  return (
-    <Link
-      href={herf}
-      className={classNames(
-        'relative inline-block shrink-0 overflow-hidden rounded-full',
-        className,
-        { 'pointer-events-none': type !== 'link' },
-      )}
-      style={{ height: size, width: size }} // 스타일로 동적으로 크기 설정
-    >
-      <Image
-        src={user?.image || '/assets/icons/basic-profile-img-.svg'}
-        alt={`${user?.username} 프로필 이미지`}
-        fill
-        priority
-        className="object-cover"
-      />
-    </Link>
+  const Avatar = (
+    <CustomImage
+      imageSrc={user?.image || '/assets/icons/basic-profile-img-.svg'}
+      alt={`${user?.username} 프로필 이미지`}
+      className={avatarClassNames}
+    />
   );
+
+  return link ? <Link href={user?.accountname || '#'}>{Avatar}</Link> : Avatar;
 }

--- a/src/hooks/usePreviewImage.ts
+++ b/src/hooks/usePreviewImage.ts
@@ -1,12 +1,16 @@
 import { useState } from 'react';
 
-export function usePreviewImage() {
+export function usePreviewImage(multiple: boolean = true) {
   const [preview, setPreview] = useState<string[]>([]);
 
   const addImage = (file: File) => {
     const reader = new FileReader();
     reader.onload = () =>
-      setPreview((prev) => [...prev, reader.result as string]);
+      setPreview((prev) =>
+        multiple
+          ? [...prev, reader.result as string]
+          : [reader.result as string],
+      );
     reader.readAsDataURL(file);
   };
 


### PR DESCRIPTION
## 📍 PR 타입

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 버그 수정
- [x] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제한 경우
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

</br>

## 🖇️ 반영 브랜치

<!-- ex) feat/login -> dev -->
refactor/profile/form -> main

</br>

## 🛠️ 작업 내용

<!-- 어떤 작업을 했는지 -->
- UserImage에 preview image를 전달할 수 있도록 수정
- usePreviewImage 훅에 이미지를 한 장만 받거나 여러장 받을 수 있도록 multiple 옵션을 추가
- register와 setValue를 사용하여 프로필 이미지 입력 구현
- ImageInput 커스텀 컴포넌트를 forwardRef로 감싸기(register는 input 요소에 직접 연결해야 하기 때문에 커스텀 컴포넌트(ImageInput)에 바로 사용할 수 없음->forwardRef를 사용해야 register의 ref를 올바르게 전달 가능)

</br>

## 💣 이슈

<!-- 작업 시 이슈 -->
