### PR TITLE
페이지 기능: 회원가입 accountname valid API 연결 및 중복확인 버튼 레이아웃 

### DIFF
--- a/src/api/apiRequests/auth.ts
+++ b/src/api/apiRequests/auth.ts
@@ -1,5 +1,7 @@
 import { postRequest } from '@/api/requests';
 import {
+  IAccountValidRequest,
+  IAccountValidResponse,
   IEmailValidRequest,
   IEmailValidResponse,
   ILoginRequest,
@@ -31,6 +33,15 @@ export const emailValid = async (data: IEmailValidRequest) => {
     '/user/emailvalid',
     data,
   );
+
+  return response;
+};
+
+export const accountValid = async (data: IAccountValidRequest) => {
+  const response = await postRequest<
+    IAccountValidResponse,
+    IAccountValidRequest
+  >('/user/accountnamevalid', data);
 
   return response;
 };

--- a/src/api/types/auth.ts
+++ b/src/api/types/auth.ts
@@ -1,14 +1,20 @@
 import { IUserBase } from './user';
 
-/* -- 공통 응답 구조 인터페이스 -- */
-export interface IBaseResponse<T> {
+/* -- 공통 응답 구조 -- */
+export interface IMessageResponse {
   message: string;
+}
+
+export interface IBaseResponse<T> extends IMessageResponse {
   user: IUserBase & { _id: string } & T;
 }
 
 /* -- 유저 기본 정보 인터페이스 -- */
 export interface IUserEmail {
   email: string;
+}
+export interface IUserAccount {
+  accountname: string;
 }
 
 export interface IUserAuth extends IUserEmail {
@@ -27,9 +33,14 @@ export interface IEmailValidRequest {
   user: IUserEmail;
 }
 
-export type IEmailValidResponse = {
-  message: string;
-};
+export type IEmailValidResponse = IMessageResponse;
+
+/* -- 계정명 유효성 검사 요청, 응답 -- */
+export interface IAccountValidRequest {
+  user: IUserAccount;
+}
+
+export type IAccountValidResponse = IMessageResponse;
 
 /* -- 로그인 요청, 응답 -- */
 export interface ILoginRequest {

--- a/src/components/common/custom-image/CustomImage.tsx
+++ b/src/components/common/custom-image/CustomImage.tsx
@@ -16,7 +16,6 @@ export default function CustomImage({
     <div className={classNames('relative overflow-hidden', className)}>
       <Image
         src={imageSrc}
-        sizes="100vw"
         alt={alt}
         fill
         className="object-cover"

--- a/src/components/common/form/auth-form/ProfileFields.tsx
+++ b/src/components/common/form/auth-form/ProfileFields.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@nextui-org/react';
 import { useFormContext } from 'react-hook-form';
 
 import ImageInput from '@/components/common/input/ImageInput';
@@ -7,7 +8,12 @@ import { usePreviewImage } from '@/hooks/usePreviewImage';
 
 import FieldsLayout from './FieldsLayout';
 
-export default function ProfileFields() {
+interface IProfileFields {
+  isDisabled: boolean;
+  onClick: () => void;
+}
+
+export default function ProfileFields({ isDisabled, onClick }: IProfileFields) {
   const { register, setValue } = useFormContext();
   const { preview, addImage } = usePreviewImage(false);
 
@@ -20,7 +26,21 @@ export default function ProfileFields() {
   };
 
   return (
-    <FieldsLayout fields={profileFields}>
+    <FieldsLayout
+      fields={profileFields}
+      customElement={{
+        accountname: (
+          <Button
+            isDisabled={isDisabled}
+            color="primary"
+            onPress={onClick}
+            className="px-1 text-white"
+          >
+            중복확인
+          </Button>
+        ),
+      }}
+    >
       <div className="relative">
         <UserImage size="110px" link={false} src={preview[0]} />
         <ImageInput

--- a/src/components/pages/EditAccountPage.tsx
+++ b/src/components/pages/EditAccountPage.tsx
@@ -2,13 +2,14 @@
 
 import '@/__mock__';
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import { IEditAccountRequest } from '@/api/types/user';
 import ProfileFields from '@/components/common/form/auth-form/ProfileFields';
 import { useHeaderContext } from '@/context/provider/HeaderContext';
 import useNavigate from '@/hooks/useNavigate';
+import useAccountNameValid from '@/queries/auth/useAccountNameValid';
 import useEditAccount from '@/queries/profile/useEditAccount';
 import useProfile from '@/queries/profile/useProfile';
 import AuthService from '@/services/AuthService';
@@ -16,11 +17,15 @@ import AuthService from '@/services/AuthService';
 export default function EditAccountPage({ className }: { className: string }) {
   const accountName = AuthService.getUser() || '';
   const { isHeaderClick, setIsHeaderClick } = useHeaderContext();
+
+  const [initialAccountName, setInitialAccountName] = useState('');
+  const [isAccountAvailable, setIsAccountAvailable] = useState(false);
   const { goTo } = useNavigate();
 
   const { data: userProfile, isLoading } = useProfile(accountName, {
     enabled: !!accountName,
   });
+  const { mutate: accountValid } = useAccountNameValid();
   const { mutate: editAccount, isSuccess: isEditAccountSuccess } =
     useEditAccount();
 
@@ -36,6 +41,14 @@ export default function EditAccountPage({ className }: { className: string }) {
     },
   });
 
+  const checkDuplicate = async () => {
+    const value = methods.getValues('user.accountname');
+    const isValid = await methods.trigger('user.accountname');
+    if (!isValid) return;
+    accountValid({ user: { accountname: value } });
+    setIsAccountAvailable(true);
+  };
+
   // 데이터가 로드되면 폼 값 업데이트. useEffect를 사용해 데이터가 변경될 때만 reset 호출
   useEffect(() => {
     if (!userProfile) return;
@@ -48,6 +61,8 @@ export default function EditAccountPage({ className }: { className: string }) {
         image: userProfile.profile.image,
       },
     });
+
+    setInitialAccountName(userProfile.profile.accountname);
   }, [userProfile, methods]);
 
   // 헤더 클릭 이벤트로 폼 제출 처리
@@ -55,11 +70,30 @@ export default function EditAccountPage({ className }: { className: string }) {
     if (isHeaderClick) {
       methods.handleSubmit((data) => {
         console.log('Data:', data);
+        const currentAccountName = data.user.accountname;
+
+        const isAccountNameChanged = currentAccountName !== initialAccountName;
+
+        // accountname이 변경되었을 경우, 중복 확인을거쳤는지 확인
+        if (isAccountNameChanged && !isAccountAvailable) {
+          // eslint-disable-next-line no-alert
+          alert('계정명을 변경하셨다면 중복 확인을 해주세요.');
+          setIsHeaderClick(false);
+          return;
+        }
+
         editAccount(data);
       })();
       setIsHeaderClick(false);
     }
-  }, [isHeaderClick, methods, setIsHeaderClick, editAccount]);
+  }, [
+    isHeaderClick,
+    methods,
+    setIsHeaderClick,
+    editAccount,
+    initialAccountName,
+    isAccountAvailable,
+  ]);
 
   useEffect(() => {
     if (isEditAccountSuccess) {
@@ -76,7 +110,10 @@ export default function EditAccountPage({ className }: { className: string }) {
     <main className={`pt-[30px] ${className}`}>
       <FormProvider {...methods}>
         <form>
-          <ProfileFields />
+          <ProfileFields
+            isDisabled={methods.watch('user.accountname')?.length < 1}
+            onClick={() => checkDuplicate()}
+          />
         </form>
       </FormProvider>
     </main>

--- a/src/components/pages/SignupPage.tsx
+++ b/src/components/pages/SignupPage.tsx
@@ -12,6 +12,7 @@ import { TITLE_TEXT } from '@/constants/titleText';
 import useHistorySync from '@/hooks/useHistorySync';
 import useNavigate from '@/hooks/useNavigate';
 import useSteps from '@/hooks/useSteps';
+import useAccountNameValid from '@/queries/auth/useAccountNameValid';
 import useEmailValid from '@/queries/auth/useEmailValid';
 import useSignup from '@/queries/auth/useSignup';
 
@@ -34,6 +35,7 @@ export default function SignupPage() {
   const [isEmailAvailable, setIsEmailAvailable] = useState(false);
 
   const { mutate: checkEmailValid } = useEmailValid();
+  const { mutate: checkAccountValid } = useAccountNameValid();
   const { mutate: signup, error, isError } = useSignup();
   const { step, goToNextStep, goToPreviousStep } = useSteps(1, 2);
   const { pushState } = useHistorySync(goToPreviousStep);
@@ -43,6 +45,12 @@ export default function SignupPage() {
     await methods.trigger('user.email'); // react-hook-form의 유효성 검사 실행
     checkEmailValid({ user: { email } });
     setIsEmailAvailable(true); // 이메일 사용 가능 상태로 설정
+  };
+
+  const handleAccountNameCheck = async () => {
+    const accountname = methods.getValues('user.accountname'); // 입력된 계정명 값 가져오기
+    await methods.trigger('user.accountname'); // react-hook-form의 유효성 검사 실행
+    checkAccountValid({ user: { accountname } });
   };
 
   const handleNext = async () => {
@@ -85,7 +93,10 @@ export default function SignupPage() {
               onClick={handleEmailAvailableCheck}
             />
           ) : (
-            <ProfileFields />
+            <ProfileFields
+              isDisabled={methods.watch('user.accountname')?.length < 1}
+              onClick={handleAccountNameCheck}
+            />
           )}
           <CustomButton
             type={isFirstStep ? 'button' : 'submit'}

--- a/src/queries/auth/useAccountNameValid.ts
+++ b/src/queries/auth/useAccountNameValid.ts
@@ -1,0 +1,21 @@
+import { useMutation } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+
+import { accountValid } from '@/api/apiRequests/auth';
+import { IAccountValidRequest, IAccountValidResponse } from '@/api/types/auth';
+
+function useAccountNameValid() {
+  const onSuccess = () => {};
+
+  const onError = (error: AxiosError) => {
+    console.error(error);
+  };
+
+  return useMutation<IAccountValidResponse, AxiosError, IAccountValidRequest>({
+    mutationFn: accountValid,
+    onSuccess,
+    onError,
+  });
+}
+
+export default useAccountNameValid;


### PR DESCRIPTION
## 📍 PR 타입

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제한 경우
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

</br>

## 🖇️ 반영 브랜치

<!-- ex) feat/login -> dev -->
page/feature/api/signup/accountname/valid -> main
</br>

## 🛠️ 작업 내용

<!-- 어떤 작업을 했는지 -->
- 계정이름 검증 요청 응답 타입 지정
- 계정이름 검증 요청 함수, 쿼리훅 작성 및 SignupPage에 적용
- ProfileFields에 customElement로 계정이름 중복확인 버튼 추가
- 이메일, 계정이름 검증 중복 코드 리팩토링
- renderStepFields()와 renderButton()을 분리하여 JSX 내부 가독성 향상
- 프로필 수정 컴포넌트에도 계정이름 검증 쿼리훅 적용 및 폼 제출 시 로직 조건 수정
  - accountname이 기존 값과 다를 경우: 중복 확인을 필수로 함
  - accountname이 기존 값과 동일할 경우: 중복 확인 없이도 제출 가능
</br>

## 💣 이슈

<!-- 작업 시 이슈 -->
