### PR TITLE
리팩토링: 로그인 구조 개선(토큰 저장 방식을 HttpOnly 쿠키 기반으로 전환)

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -5,7 +5,9 @@ import { handleResponse, handleResponseError } from './helper/responseHandlers';
 
 // axios 인스턴스 생성
 const instance: AxiosInstance = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_BASE_URL,
+  // baseURL: process.env.NEXT_PUBLIC_BASE_URL,
+  baseURL: '/api', // Next.js의 API 라우트 사용
+  withCredentials: true,
 });
 
 // 인터셉터 추가

--- a/src/app/api/post/feed/route.ts
+++ b/src/app/api/post/feed/route.ts
@@ -1,0 +1,25 @@
+import { cookies } from 'next/headers';
+import { NextResponse } from 'next/server';
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const limit = searchParams.get('limit');
+  const skip = searchParams.get('skip');
+
+  const token = cookies().get('token')?.value;
+
+  const res = await fetch(
+    `${process.env.BACKEND_BASE_URL}/post/feed/?limit=${limit}&skip=${skip}`,
+    {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      cache: 'no-store', // 항상 최신 데이터
+    },
+  );
+
+  const data = await res.json();
+  return NextResponse.json(data);
+}

--- a/src/app/api/user/login/route.ts
+++ b/src/app/api/user/login/route.ts
@@ -1,0 +1,40 @@
+import { cookies } from 'next/headers';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(request: NextRequest) {
+  const body = await request.json();
+
+  // 1. 기존 외부 API 호출
+  const response = await fetch(
+    `${process.env.NEXT_PUBLIC_BASE_URL}/user/login`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    },
+  );
+
+  const data = await response.json();
+
+  if (response.ok && data.user?.token) {
+    // 2. 🛡️ HttpOnly 쿠키로 보안 저장
+    cookies().set('token', data.user.token, {
+      httpOnly: true, // XSS 공격 방어
+      secure: process.env.NODE_ENV === 'production', // HTTPS에서만 전송
+      sameSite: 'strict', // CSRF 공격 방어
+      maxAge: 60 * 60 * 24 * 3, // 3일
+      path: '/',
+    });
+
+    // 3. 🔒 클라이언트에는 토큰 없이 안전한 응답
+    return NextResponse.json({
+      ...data,
+      user: {
+        ...data.user,
+        token: undefined,
+      },
+    });
+  }
+
+  return NextResponse.json(data, { status: response.status });
+}

--- a/src/components/pages/LoginPage.tsx
+++ b/src/components/pages/LoginPage.tsx
@@ -31,9 +31,9 @@ export default function LoginPage() {
   const onSubmit = async (data: ILoginRequest) => {
     try {
       const response = await login(data);
-      const { token, accountname } = response.user;
-      if (token && accountname) {
-        AuthService.login(accountname, token);
+      const { accountname } = response.user;
+      if (accountname) {
+        AuthService.login(accountname);
         goTo('/feed');
       }
     } catch (error) {

--- a/src/components/pages/PostFeedPage.tsx
+++ b/src/components/pages/PostFeedPage.tsx
@@ -2,8 +2,6 @@
 
 'use client';
 
-import '@/__mock__';
-
 import TopButton from '@/components/common/button/TopButton';
 import InfiniteScrollLoader from '@/components/common/loading/InfiniteScrollLoader';
 import PostItem from '@/components/common/post-item/PostItem';

--- a/src/services/AuthService.ts
+++ b/src/services/AuthService.ts
@@ -2,39 +2,25 @@ import StorageService from './StorageService';
 
 class AuthService {
   private static userAccount: string | null = StorageService.get('userAccount');
-  private static token: string | null = StorageService.get('token');
 
-  static login(userAccount: string, token: string): void {
+  static login(userAccount: string): void {
     this.userAccount = userAccount;
-    this.token = token;
     StorageService.setStorageAdapter('localStorage');
     StorageService.set('userAccount', userAccount);
-    StorageService.setStorageAdapter('cookieStorage');
-    StorageService.set('token', token, {
-      expires: 3,
-      path: '',
-    });
   }
 
   static logout(): void {
     this.userAccount = null;
-    this.token = null;
     StorageService.setStorageAdapter('localStorage');
     StorageService.remove('userAccount');
-    StorageService.setStorageAdapter('cookieStorage');
-    StorageService.remove('token');
   }
 
   static getUser(): string | null {
     return this.userAccount || StorageService.get('userAccount');
   }
 
-  static getToken(): string | null {
-    return this.token || StorageService.get('token');
-  }
-
   static isAuthenticated(): boolean {
-    return !!this.userAccount && !!this.token;
+    return !!this.userAccount;
   }
 }
 


### PR DESCRIPTION
## 📍 PR 타입

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 버그 수정
- [x] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제한 경우
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

</br>

## 🖇️ 반영 브랜치

<!-- ex) feat/login -> dev -->
refactor-login -> main
</br>

## 🛠️ 작업 내용

<!-- 어떤 작업을 했는지 -->

- AuthService에서 토큰 저장 로직 제거
- LoginPage에서 로그인 후 토큰 저장 제거, 계정명만 상태로 관리
- 로그인 서버 라우트 생성: 로그인 요청 후 토큰을 HttpOnly + Secure 쿠키에 저장하도록 구현
- 프록시를 기본 baseURL로 설정
- 피드 서버 라우트 생성: Next 서버(BFF)가 쿠키를 읽고, 자동으로 Authorization 헤더를 붙여서 백엔드로 포워딩

</br>

## 💣 이슈
 기존 코드: **클라이언트(JS)에서 토큰을 직접 저장/주입** → HttpOnly 사용 불가, XSS/탈취 위험.
 리팩토링: **Next.js 서버가 토큰을 HttpOnly 쿠키로만 관리**하고, **클라이언트 보호 API는 프록시(BFF)로 호출**.
<!-- 작업 시 이슈 -->
